### PR TITLE
5 - Provide a preseed file that preseeds license signing for java package

### DIFF
--- a/manifests/package_debian.pp
+++ b/manifests/package_debian.pp
@@ -20,9 +20,14 @@ class java::package_debian(
   $distribution
 ) {
 
+  file { "/var/local/sun-java6.preseed":
+    content => template("${module_name}/sun-java6.preseed"),
+  }
   package { 'java':
     ensure => $version,
     name   => $distribution,
+    responsefile => "/var/local/sun-java6.preseed",
+    require => File["/var/local/sun-java6.preseed"],
   }
 
 }

--- a/templates/sun-java6.preseed
+++ b/templates/sun-java6.preseed
@@ -1,0 +1,3 @@
+sun-java6-bin   shared/accepted-sun-dlj-v1-1    boolean true
+sun-java6-jdk   shared/accepted-sun-dlj-v1-1    boolean true
+sun-java6-jre   shared/accepted-sun-dlj-v1-1    boolean true


### PR DESCRIPTION
This patch fixes issue 5, by providing a preseed file that contains license sign-off for the required packages.
