### PR TITLE
Allow distributions starting with string `java`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class java(
   $version      = 'installed'
 ) {
 
-  validate_re($distribution, '^jdk$|^jre$')
+  validate_re($distribution, '^jdk$|^jre$|^java.*$')
   validate_re($version, 'installed|^[._0-9a-zA-Z:-]+$')
 
   anchor { 'java::begin': }


### PR DESCRIPTION
Some java distributions can start with java, such as java-sun or java-1.6.0-openjdk.  We should allow these to be specified
