### PR TITLE
add support for Amazon Linux as an operating system

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class java(
 
   case $operatingsystem {
 
-    centos, redhat, oel: {
+    centos, redhat, oel, amazon: {
 
       class { 'java::package_redhat':
         version      => $version,


### PR DESCRIPTION
The Amazon Linux AMI on EC2 reports OS as "Amazon" to facter - it is CentOS based.
