### PR TITLE
Add special case for fedora operating systems, where java is installable...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,11 +26,20 @@ class java(
 
     'RedHat': {
 
-      class { 'java::package_redhat':
-        version      => $version,
-        distribution => $distribution,
-        require      => Anchor['java::begin'],
-        before       => Anchor['java::end'],
+      if ($operatingsystem == 'Fedora') {
+        class { 'java::package_redhat':
+          version      => $version,
+          distribution => 'java',
+          require      => Anchor['java::begin'],
+          before       => Anchor['java::end'],
+        }
+      } else {
+        class { 'java::package_redhat':
+          version      => $version,
+          distribution => $distribution,
+          require      => Anchor['java::begin'],
+          before       => Anchor['java::end'],
+        }
       }
 
     }


### PR DESCRIPTION
..., but jdk is not.
