### PR TITLE
Add support for OpenSUSE

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,8 +44,17 @@ class java::params {
       $jre_package = 'runtime/java/jre-7'
     }
     'Suse': {
-      $jdk_package = 'java-1_6_0-ibm-devel'
-      $jre_package = 'java-1_6_0-ibm'
+      case $::operatingsystem {
+        default: {
+          $jdk_package = 'java-1_6_0-ibm-devel'
+          $jre_package = 'java-1_6_0-ibm'
+        }
+
+        'OpenSuSE': {
+          $jdk_package = 'java-1_7_0-openjdk-devel'
+          $jre_package = 'java-1_7_0-openjdk'
+        }
+      }
     }
   }
 

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -28,4 +28,9 @@ describe 'java', :type => :class do
     it { should contain_package('java').with_name('java-1.6.0-openjdk-devel') }
   end
 
+  context 'select default for OpenSUSE 12.3' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3'}}
+    it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
+  end
+
 end


### PR DESCRIPTION
I've tested this by running it on my machine, but I'm not sure if the specs are right - `rake spec` fails with

```
/usr/bin/ruby1.9 -S rspec spec/classes/java_spec.rb --color
/usr/bin/ruby1.9: No such file or directory -- rspec (LoadError)
rake aborted!
/usr/bin/ruby1.9 -S rspec spec/classes/java_spec.rb --color failed
```
