### PR TITLE
Remove empty package test and validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,9 +47,6 @@ class java(
   include java::params
 
   validate_re($version, 'present|installed|latest|^[.+_0-9a-zA-Z:-]+$')
-  if $package != undef {
-    validate_slength($package,255,1)
-  }
 
   if has_key($java::params::java, $distribution) {
     $default_package_name     = $java::params::java[$distribution]['package']

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -173,28 +173,4 @@ describe 'failure cases' do
 
     apply_manifest(pp, :expect_failures => true)
   end
-
-  # C14716
-  it 'should fail to install java with a blank package' do
-    pp = <<-EOS
-      class { 'java':
-        package => '',
-      }
-    EOS
-
-    apply_manifest(pp, :expect_failures => true)
-  end
-
-  context 'non-debian systems', :if => fact('osfamily') != 'Debian' do
-    # C14717
-    it 'should fail to install java with a blank package' do
-      pp = <<-EOS
-        class { 'java':
-          package => '',
-        }
-      EOS
-
-      apply_manifest(pp, :expect_failures => true)
-    end
-  end
 end


### PR DESCRIPTION
an empty variable is apparently the same thing as undef, which causes
the packages to be selected as usual.
