### PR TITLE
cosmetic: default in last position

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,10 +13,8 @@
 class java::params {
 
   case $::osfamily {
-    default: { fail("unsupported platform ${::osfamily}") }
     'RedHat': {
       case $::operatingsystem {
-        default: { fail("unsupported os ${::operatingsystem}") }
         'RedHat', 'CentOS', 'OracleLinux', 'Scientific': {
           if (versioncmp($::operatingsystemrelease, '5.0') < 0) {
             $jdk_package = 'java-1.6.0-sun-devel'
@@ -39,6 +37,7 @@ class java::params {
           $jdk_package = 'java-1.7.0-openjdk-devel'
           $jre_package = 'java-1.7.0-openjdk'
         }
+        default: { fail("unsupported os ${::operatingsystem}") }
       }
       $java = {
         'jdk' => { 'package' => $jdk_package, },
@@ -129,5 +128,6 @@ class java::params {
         'jre' => { 'package' => $jre_package, },
       }
     }
+    default: { fail("unsupported platform ${::osfamily}") }
   }
 }


### PR DESCRIPTION
The main motivation for this change is compatibility with puppetresources (https://github.com/bartavelle/language-puppet).

IMHO, it makes much more sense this way because all cases are checked order wise.
