### PR TITLE
Add Java alternatives for RHEL based distros.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ class { 'java':
 
 * `java::params`: Builds a hash of jdk/jre packages for all compatible operating systems. 
 
-* `java::config`: Configures the Java alternatives on Debian systems.
+* `java::config`: Configures the Java alternatives.
 
 ###Parameters:
 
@@ -58,9 +58,9 @@ The following parameters are available in the java module:
 
 * `package`: The name of the Java package. This is configurable in case you want to install a non-standard Java package. If not set, the module will install the appropriate package for the `distribution` parameter and target platform. If you set `package`, the `distribution` parameter will do nothing. 
 
-* `java_alternative`: The name of the Java alternative to use on Debian systems. The command 'update-java-alternatives -l' will show which choices are available. If you specify a particular package, you will usually want to specify which Java alternative to use. If you set this parameter, you also need to set the `java_alternative_path`.
+* `java_alternative`: The name of the Java alternative to use. The command 'update-java-alternatives -l' will show which choices are available. If you specify a particular package, you will usually want to specify which Java alternative to use. If you set this parameter, you also need to set the `java_alternative_path`.
 
-* `java_alternative_path`: The path to the 'java' command on Debian systems. Since the alternatives system makes it difficult to verify which alternative is actually enabled, this is required to ensure the correct JVM is enabled.
+* `java_alternative_path`: The path to the 'java' command. Since the alternatives system makes it difficult to verify which alternative is actually enabled, this is required to ensure the correct JVM is enabled.
 
 ##Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,26 @@ class java::config ( ) {
         }
       }
     }
+    'RedHat': {
+      if $java::use_java_alternative != undef and $java::use_java_alternative_path != undef {
+        # The standard packages install alternatives, custom packages do not
+        # For the stanard packages java::params needs these added.
+        if $java::use_java_package_name != $java::default_package_name {
+          exec { 'create-java-alternatives':
+            path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+            command => "alternatives --install ${java::use_java_alternative} java ${$java::use_java_alternative_path} 20000" ,
+            unless  => "alternatives --display java | grep -q ${$java::use_java_alternative_path}",
+            before  => Exec['update-java-alternatives']
+          }
+        }
+
+        exec { 'update-java-alternatives':
+          path    => '/usr/bin:/usr/sbin',
+          command => "alternatives --set java ${$java::use_java_alternative_path}" ,
+          unless  => "test /etc/alternatives/java -ef '${java::use_java_alternative_path}'",
+        }
+      }
+    }
     default: {
       # Do nothing.
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,7 @@ class java::params {
           $jre_package = 'java-1_6_0-ibm'
         }
 
-        "SLES": {
+        'SLES': {
           case $::operatingsystemmajrelease{
             default: {
               $jdk_package = 'java-1_6_0-ibm-devel'

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -15,6 +15,15 @@ describe 'java', :type => :class do
   context 'select openjdk for Centos 6.2' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.2'} }
     it { should contain_package('java').with_name('java-1.6.0-openjdk-devel') }
+    it { should_not contain_exec('update-java-alternatives') }
+  end
+
+  context 'select Oracle JRE with alternatives for Centos 6.3' do
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3'} }
+    let(:params) { { 'package' => 'jre', 'java_alternative' => '/usr/bin/java', 'java_alternative_path' => '/usr/java/jre1.7.0_67/bin/java'} }
+    it { should contain_package('java').with_name('jre') }
+    it { should contain_exec('create-java-alternatives').with_command('alternatives --install /usr/bin/java java /usr/java/jre1.7.0_67/bin/java 20000') }
+    it { should contain_exec('update-java-alternatives').with_command('alternatives --set java /usr/java/jre1.7.0_67/bin/java') }
   end
 
   context 'select openjdk for Fedora' do
@@ -48,7 +57,7 @@ describe 'java', :type => :class do
   end
 
   context 'select Oracle JRE for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', } }
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'oracle-jre' } }
     it { should contain_package('java').with_name('oracle-j2re1.7') }
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
@@ -61,14 +70,14 @@ describe 'java', :type => :class do
   end
 
   context 'select Oracle JRE for Debian Squeeze' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5'} }
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { should contain_package('java').with_name('sun-java6-jre') }
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
   end
 
   context 'select random alternative for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1'} }
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     let(:params) { { 'java_alternative' => 'bananafish' } }
     it { should contain_package('java').with_name('openjdk-7-jdk') }
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set bananafish --jre') }

--- a/tests/alternative.pp
+++ b/tests/alternative.pp
@@ -1,0 +1,5 @@
+class { 'java':
+  package               => 'jdk-8u25-linux-x64',
+  java_alternative      => 'jdk1.8.0_25',
+  java_alternative_path => '/usr/java/jdk1.8.0_25/jre/bin/java'
+}


### PR DESCRIPTION
This is a followup to pull request #61.

The code was contributed by @dstockman on the PR referenced above.

The reason I did not include the java alternative updates in java::params is because the default RPM packages for openJDK automatically set the java alternatives when installed. The only time this would be used is when installing an alternative package suck as Oracle Java.

@mhaskel 
