### PR TITLE
Test fix for RHEL with alternatives

### DIFF
--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -195,7 +195,7 @@ describe 'failure cases' do
   # C14717
   # C14719
   # C14725
-  it 'should fail on debian when passed fake java_alternative and path' do
+  it 'should fail on debian or RHEL when passed fake java_alternative and path' do
     pp = <<-EOS
       class { 'java':
         java_alternative      => 'whatever',
@@ -203,7 +203,7 @@ describe 'failure cases' do
       }
     EOS
 
-    if fact('osfamily') == 'Debian'
+    if fact('osfamily') == 'Debian' or fact('osfamily') == 'RedHat'
       apply_manifest(pp, :expect_failures => true)
     else
       apply_manifest(pp, :catch_failures => true)


### PR DESCRIPTION
Alternatives support was added in #89, but the test wasn't updated to
expect failures when invalid alternatives are passed to RHEL systems.
