### PR TITLE
Use --jre-headless instead of --jre

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@ class java::config ( ) {
       if $java::use_java_alternative != undef and $java::use_java_alternative_path != undef {
         exec { 'update-java-alternatives':
           path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-          command => "update-java-alternatives --set ${java::use_java_alternative} --jre",
+          command => "update-java-alternatives --set ${java::use_java_alternative} ${java::jre_flag}",
           unless  => "test /etc/alternatives/java -ef '${java::use_java_alternative_path}'",
         }
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,11 @@ class java(
     default => $java_alternative_path,
   }
 
+  $jre_flag = $use_java_package_name ? {
+    /headless/ => '--jre-headless',
+    default    => '--jre'
+  }
+
   anchor { 'java::begin:': }
   ->
   package { 'java':

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -63,6 +63,13 @@ describe 'java', :type => :class do
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
   end
 
+  context 'select OpenJDK JRE for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre' } }
+    it { should contain_package('java').with_name('openjdk-7-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
+  end
+
   context 'select default for Debian Squeeze' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
     it { should contain_package('java').with_name('openjdk-6-jdk') }
@@ -74,6 +81,13 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { should contain_package('java').with_name('sun-java6-jre') }
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
+  end
+
+  context 'select OpenJDK JRE for Debian Squeeze' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre', } }
+    it { should contain_package('java').with_name('openjdk-6-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
   end
 
   context 'select random alternative for Debian Wheezy' do


### PR DESCRIPTION
In some cases it can cause problems and report these kind of errors:

$ update-java-alternatives -s /usr/lib/jvm/java-1.7.0-openjdk-amd64 --jre
update-alternatives: error: no alternatives for policytool
update-alternatives: error: no alternatives for policytool