### PR TITLE
Update java_version.rb

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -14,7 +14,7 @@
 if Facter::Util::Resolution.which('java')
   Facter.add(:java_version) do
     setcode do
-      Facter::Util::Resolution.exec('java -version 2>&1').lines.first.split(/"/)[1].strip
+      Facter::Util::Resolution.exec('java -Xmx512m -version 2>&1').lines.first.split(/"/)[1].strip
     end
   end
 end


### PR DESCRIPTION
Add -Xmx512m, since on large systems (eg. my > 128 GB RAM hosts; But I believe it starts at 64 GB), java refuses to start with no such option.

Example:
# java -version
Error occurred during initialization of VM
Could not reserve enough space for object heap
Could not create the Java virtual machine.

And with:
# java -Xmx512m -version
java version "1.6.0_91"
Java(TM) SE Runtime Environment (build 1.6.0_91-b31)
Java HotSpot(TM) 64-Bit Server VM (build 20.91-b07, mixed mode)