### PR TITLE
Add -Xmx512m to make large systems happy.

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -14,7 +14,7 @@
 if Facter::Util::Resolution.which('java')
   Facter.add(:java_version) do
     setcode do
-      Facter::Util::Resolution.exec('java -Xmx512m -version 2>&1').lines.first.split(/"/)[1].strip
+      Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
     end
   end
 end

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -14,7 +14,7 @@
 if Facter::Util::Resolution.which('java')
   Facter.add(:java_version) do
     setcode do
-      Facter::Util::Resolution.exec('java -version 2>&1').lines.first.split(/"/)[1].strip
+      Facter::Util::Resolution.exec('java -Xmx512m -version 2>&1').lines.first.split(/"/)[1].strip
     end
   end
 end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -14,7 +14,7 @@ Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         EOS
         Facter::Util::Resolution.expects(:which).with("java").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("java -version 2>&1").returns(java_version_output)
+        Facter::Util::Resolution.expects(:exec).with("java -Xmx512m -version 2>&1").returns(java_version_output)
         Facter.fact(:java_version).value.should == "1.7.0_71"
       end
     end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -14,7 +14,7 @@ Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         EOS
         Facter::Util::Resolution.expects(:which).with("java").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("java -Xmx512m -version 2>&1").returns(java_version_output)
+        Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
         Facter.fact(:java_version).value.should == "1.7.0_71"
       end
     end


### PR DESCRIPTION
Result without this option on large system:

# java -version -Xmx512m
Error occurred during initialization of VM
Could not reserve enough space for object heap
Could not create the Java virtual machine.

With this option:
# java -Xmx512m -version
java version "1.6.0_91"
Java(TM) SE Runtime Environment (build 1.6.0_91-b31)
Java HotSpot(TM) 64-Bit Server VM (build 20.91-b07, mixed mode)