### PR TITLE
Improve java_version fact maintainability

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -11,9 +11,9 @@
 #
 # Notes:
 #   None
-if Facter::Util::Resolution.which('java')
-  Facter.add(:java_version) do
-    setcode do
+Facter.add(:java_version) do
+  setcode do
+    if Facter::Util::Resolution.which('java')
       Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
     end
   end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -15,7 +15,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         EOS
         Facter::Util::Resolution.expects(:which).with("java").returns(true)
         Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
-        Facter.fact(:java_version).value.should == "1.7.0_71"
+        Facter.value(:java_version).should == "1.7.0_71"
       end
     end
 
@@ -23,7 +23,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
       it do
         Facter::Util::Resolution.stubs(:exec)
         Facter::Util::Resolution.expects(:which).with("java").returns(false)
-        Facter.fact(:java_version).should be_nil
+        Facter.value(:java_version).should be_nil
       end
     end
   end


### PR DESCRIPTION
This makes alternate fact resolutions (like for example the one suggested in [the discussion on #101](https://github.com/puppetlabs/puppetlabs-java/pull/101#discussion_r24376000)) less weird.