### PR TITLE
WIP - Update tests to work on rspec-puppet 1.0 and 2.0

### DIFF
--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -181,7 +181,7 @@ describe 'java', :type => :class do
     ].each do |facts|
       let(:facts) { facts }
       it "should fail on #{facts[:operatingsystem]} #{facts[:operatingsystemrelease]}" do
-        expect { subject }.to raise_error Puppet::Error, /unsupported platform/
+        expect { is_expected.to compile }.to raise_error /unsupported platform/
       end
     end
   end


### PR DESCRIPTION
Rspec-puppet 2.0 has some backwards-incompatible changes with
rspec-puppet 1.0. This patch should make the tests compatible with both
versions.