### PR TITLE
Add support for OpenBSD, and also add some regression tests.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ class { 'java':
 
 * `java::config`: Configures the Java alternatives.
 
-* `java::params`: Builds a hash of jdk/jre packages for all compatible operating systems. 
+* `java::params`: Builds a hash of jdk/jre packages for all compatible operating systems.
 
 ####Parameters
 The following parameters are available in `java`:
@@ -102,10 +102,17 @@ OpenJDK is supported on:
 * Ubuntu 10.04, 12.04, 14.04
 * Solaris 11
 * SLES 11 SP1, 12 
+* OpenBSD 5.6, 5.7
 
 Sun Java is supported on:  
 
 * Debian 6
+
+### A note to OpenBSD
+OpenBSD packages install Java JRE/JDK in a unique directory structure, not linking
+the binaries to a standard directory. Because of that, the path to this location
+is hardcoded in the java_version fact. Whenever a Java upgrade to a newer
+version/path will be done on OpenBSD, it has to be adapted there.
 
 ##Development
 

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -18,3 +18,14 @@ Facter.add(:java_version) do
     end
   end
 end
+Facter.add(:java_version) do
+  confine :operatingsystem => 'OpenBSD'
+  has_weight 100
+  setcode do
+    Facter::Util::Resolution.with_env("PATH" => '/usr/local/jdk-1.7.0/jre/bin:/usr/local/jre-1.7.0/bin') do
+      if Facter::Util::Resolution.which('java')
+        Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
+      end
+    end
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -127,6 +127,12 @@ class java::params {
         }
       }
     }
+    'OpenBSD': {
+      $java = {
+        'jdk' => { 'package' => 'jdk', },
+        'jre' => { 'package' => 'jre', },
+      }
+    }
     'Solaris': {
       $java = {
         'jdk' => { 'package' => 'developer/java/jdk-7', },

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -158,6 +158,17 @@ describe 'java', :type => :class do
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
   end
 
+  context 'select jdk for OpenBSD' do
+    let(:facts) { {:osfamily => 'OpenBSD'} }
+    it { should contain_package('java').with_name('jdk') }
+  end
+
+  context 'select jre for OpenBSD' do
+    let(:facts) { {:osfamily => 'OpenBSD'} }
+    let(:params) { { 'distribution' => 'jre' } }
+    it { should contain_package('java').with_name('jre') }
+  end
+
   describe 'incompatible OSs' do
     [
       {

--- a/spec/unit/facter/java_patch_level_spec.rb
+++ b/spec/unit/facter/java_patch_level_spec.rb
@@ -17,8 +17,8 @@ describe Facter::Util::Fact do
       end
     end
 
-    context "if java is installed" do
-      context 'returns java patch version extracted from java_version fact' do
+    context "if java is not installed" do
+      context 'returns nil' do
         before :each do
           Facter.fact(:java_version).stubs(:value).returns(nil)
         end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -7,23 +7,59 @@ describe Facter::Util::Fact do
 
   describe "java_version" do
     context 'returns java version when java present' do
-      it do
-        java_version_output = <<-EOS
+      context 'on OpenBSD' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
+        end
+        let(:facts) { {:operatingsystem => 'OpenBSD'} }
+        it do
+          java_version_output = <<-EOS
+openjdk version "1.7.0_71"
+OpenJDK Runtime Environment (build 1.7.0_71-b14)
+OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
+          EOS
+          Facter::Util::Resolution.expects(:which).with("java").returns('/usr/local/jdk-1.7.0/jre/bin/java')
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter.value(:java_version).should == "1.7.0_71"
+        end
+      end
+      context 'on other systems' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("MyOS")
+        end
+        let(:facts) { {:operatingsystem => 'MyOS'} }
+        it do
+          java_version_output = <<-EOS
 java version "1.7.0_71"
 Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
-        EOS
-        Facter::Util::Resolution.expects(:which).with("java").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
-        Facter.value(:java_version).should == "1.7.0_71"
+          EOS
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter.value(:java_version).should == "1.7.0_71"
+        end
       end
     end
 
     context 'returns nil when java not present' do
-      it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with("java").returns(false)
-        Facter.value(:java_version).should be_nil
+      context 'on OpenBSD' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
+        end
+        let(:facts) { {:operatingsystem => 'OpenBSD'} }
+        it do
+          Facter::Util::Resolution.stubs(:exec)
+          Facter.value(:java_version).should be_nil
+        end
+      end
+      context 'on other systems' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("MyOS")
+        end
+        let(:facts) { {:operatingsystem => 'MyOS'} }
+        it do
+          Facter::Util::Resolution.expects(:which).with("java").returns(false)
+          Facter.value(:java_version).should be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
Add info about OpenBSD support to README.md and metadata.json

Thanks to the lots of feedback from the other pull requests, here is a new try, following the suggestsions. 

I first came up with something like:

Facter.add(:java_version) do
...
something for non-OpenBSD
...
end
Facter.add(:java_version) do
confine :osfamily => 'OpenBSD'
...
end

that was easy, worked well on a machine that had Java installed, and also spec tests were easily written and all fine. However, on a OpenBSD machine without java installed I got warnings running facter like this:

facter -p java_version                                             
Could not retrieve fact='java_version', resolution='<anonymous>': undefined method `lines' for nil:NilClass

Those are not really an option. BTW, running Puppet 3.7.4, Facter 2.3.0. Facter only just got updated in the Ports tree to 2.4.1 Today, so haven't tested with that version yet.

If installing jdk or jre, doesn't matter, the java binary I point to, is there with both variants.

Since there is no OpenBSD yet with java 1.8, I haven't bothered yet, to fiddle with confines and versions to distinguish. Since OpenBSD is not primary target for any java development, it also might still take some time for it to appear as a port.
