### PR TITLE
Support ubuntu vivid

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,6 +109,22 @@ class java::params {
             },
           }
         }
+        'vivid': {
+          $java =  {
+            'jdk' => {
+              'package'          => 'openjdk-8-jdk',
+              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+            },
+            'jre' => {
+              'package'          => 'openjdk-8-jre-headless',
+              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+            }
+          }
+        }
       }
     }
     'Solaris': {

--- a/spec/acceptance/nodesets/ubuntu-server-1504-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1504-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-server-1504-x64:
+    roles:
+      - master
+    platform: ubuntu-15.04-amd64
+    box : puppetlabs/ubuntu-15.04-64-nocm
+    box_url : https://vagrantcloud.com/puppetlabs/ubuntu-15.04-64-nocm
+    hypervisor : vagrant
+CONFIG:
+  log_level   : debug
+  type: git

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -108,6 +108,18 @@ describe 'java', :type => :class do
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set bananafish --jre') }
   end
 
+  context 'select jdk for Ubuntu Vivid (15.04)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jdk' } }
+    it { should contain_package('java').with_name('openjdk-8-jdk') }
+  end
+
+  context 'select jre for Ubuntu Vivid (15.04)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre' } }
+    it { should contain_package('java').with_name('openjdk-8-jre-headless') }
+  end
+
   context 'select openjdk for Amazon Linux' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64'} }
     it { should contain_package('java').with_name('java-1.7.0-openjdk-devel') }


### PR DESCRIPTION
Add support for vivid (Ubuntu 15.04). 

I upgraded the default Java Version to use to 8, since it is available as package from Canonical. If someone gives me some pointers on the Oracle packages, I will happily add them. I use only OpenJDK myself
