### PR TITLE
Support more distribution strings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,78 +51,117 @@ class java::params {
       }
     }
     'Debian': {
+
+      $debian_oracle_java_architecture = $::architecture ? {
+        'i386'  => 'i586', # 32 bit
+        default => 'x64',  # 64 bit
+      }
+
+      $debian_jdk6 = {
+        'package'          => 'openjdk-6-jdk',
+        'alternative'      => "java-6-openjdk-${::architecture}",
+        'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
+        'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
+      }
+      $debian_jre6 = {
+        'package'          => 'openjdk-6-jre-headless',
+        'alternative'      => "java-6-openjdk-${::architecture}",
+        'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
+        'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
+      }
+      $debian_jdk7 = {
+        'package'          => 'openjdk-7-jdk',
+        'alternative'      => "java-1.7.0-openjdk-${::architecture}",
+        'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
+        'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+      }
+      $debian_jre7 = {
+        'package'          => 'openjdk-7-jre-headless',
+        'alternative'      => "java-1.7.0-openjdk-${::architecture}",
+        'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
+        'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+      }
+      $debian_jdk8 = {
+        'package'          => 'openjdk-8-jdk',
+        'alternative'      => "java-1.8.0-openjdk-${::architecture}",
+        'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
+        'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+      }
+      $debian_jre8 = {
+        'package'          => 'openjdk-8-jre-headless',
+        'alternative'      => "java-1.8.0-openjdk-${::architecture}",
+        'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
+        'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+      }
+      $debian_sun_jdk6 = {
+        'package'          => 'sun-java6-jdk',
+        'alternative'      => 'java-6-sun',
+        'alternative_path' => '/usr/lib/jvm/java-6-sun/jre/bin/java',
+        'java_home'        => '/usr/lib/jvm/java-6-sun/jre/',
+      }
+      $debian_sun_jre6 = {
+        'package'          => 'sun-java6-jre',
+        'alternative'      => 'java-6-sun',
+        'alternative_path' => '/usr/lib/jvm/java-6-sun/jre/bin/java',
+        'java_home'        => '/usr/lib/jvm/java-6-sun/jre/',
+      }
+      $debian_oracle_jdk7 = {
+        'package'          => 'oracle-j2sdk1.7',
+        'alternative'      => 'j2sdk1.7-oracle',
+        'alternative_path' => '/usr/lib/jvm/j2sdk1.7-oracle/jre/bin/java',
+        'java_home'        => '/usr/lib/jvm/j2sdk1.7-oracle/jre/',
+      }
+      $debian_oracle_jre7 = {
+        'package'          => 'oracle-j2re1.7',
+        'alternative'      => 'j2re1.7-oracle',
+        'alternative_path' => '/usr/lib/jvm/j2re1.7-oracle/bin/java',
+        'java_home'        => '/usr/lib/jvm/j2re1.7-oracle/',
+      }
+      $debian_oracle_jdk8 = {
+        'package'          => 'oracle-java8-jdk',
+        'alternative'      => "jdk-8-oracle-${debian_oracle_java_architecture}",
+        'alternative_path' => "/usr/lib/jvm/jdk-8-oracle-${debian_oracle_java_architecture}/jre/bin/java",
+        'java_home'        => "/usr/lib/jvm/jdk-8-oracle-${debian_oracle_java_architecture}/",
+      }
+      $debian_oracle_jre8 = {
+        'package'          => 'oracle-java8-jre',
+        'alternative'      => "jre-8-oracle-${debian_oracle_java_architecture}",
+        'alternative_path' => "/usr/lib/jvm/jre-8-oracle-${debian_oracle_java_architecture}/bin/java",
+        'java_home'        => "/usr/lib/jvm/jre-8-oracle-${debian_oracle_java_architecture}/",
+      }
+
       case $::lsbdistcodename {
         default: { fail("unsupported release ${::lsbdistcodename}") }
         'lenny', 'squeeze', 'lucid', 'natty': {
           $java  = {
-            'jdk' => {
-              'package'          => 'openjdk-6-jdk',
-              'alternative'      => "java-6-openjdk-${::architecture}",
-              'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
-              'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
-            },
-            'jre' => {
-              'package'          => 'openjdk-6-jre-headless',
-              'alternative'      => "java-6-openjdk-${::architecture}",
-              'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
-              'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
-            },
-            'sun-jre' => {
-              'package'          => 'sun-java6-jre',
-              'alternative'      => 'java-6-sun',
-              'alternative_path' => '/usr/lib/jvm/java-6-sun/jre/bin/java',
-              'java_home'        => '/usr/lib/jvm/java-6-sun/jre/',
-            },
-            'sun-jdk' => {
-              'package'          => 'sun-java6-jdk',
-              'alternative'      => 'java-6-sun',
-              'alternative_path' => '/usr/lib/jvm/java-6-sun/jre/bin/java',
-              'java_home'        => '/usr/lib/jvm/java-6-sun/jre/',
-            },
+            'jdk'     => $debian_jdk6,
+            'jre'     => $debian_jre6,
+            'sun-jre' => $debian_sun_jre6,
+            'sun-jdk' => $debian_sun_jdk6,
           }
         }
         'wheezy', 'jessie', 'precise','quantal','raring','saucy', 'trusty', 'utopic': {
           $java =  {
-            'jdk' => {
-              'package'          => 'openjdk-7-jdk',
-              'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
-            },
-            'jre' => {
-              'package'          => 'openjdk-7-jre-headless',
-              'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
-            },
-            'oracle-jre' => {
-              'package'          => 'oracle-j2re1.7',
-              'alternative'      => 'j2re1.7-oracle',
-              'alternative_path' => '/usr/lib/jvm/j2re1.7-oracle/bin/java',
-              'java_home'        => '/usr/lib/jvm/j2re1.7-oracle/',
-            },
-            'oracle-jdk' => {
-              'package'          => 'oracle-j2sdk1.7',
-              'alternative'      => 'j2sdk1.7-oracle',
-              'alternative_path' => '/usr/lib/jvm/j2sdk1.7-oracle/jre/bin/java',
-              'java_home'        => '/usr/lib/jvm/j2sdk1.7-oracle/jre/',
-            },
+            'jdk'         => $debian_jdk7,
+            'jre'         => $debian_jre7,
+            'jdk7'        => $debian_jdk7,
+            'jre7'        => $debian_jre7,
+            'jdk8'        => $debian_jdk8,
+            'jre8'        => $debian_jre8,
+            'oracle-jdk'  => $debian_oracle_jdk7,
+            'oracle-jre'  => $debian_oracle_jre7,
+            'oracle-jdk7' => $debian_oracle_jdk7,
+            'oracle-jre7' => $debian_oracle_jre7,
+            'oracle-jdk8' => $debian_oracle_jdk8,
+            'oracle-jre8' => $debian_oracle_jre8,
           }
         }
         'vivid': {
           $java =  {
-            'jdk' => {
-              'package'          => 'openjdk-8-jdk',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
-            },
-            'jre' => {
-              'package'          => 'openjdk-8-jre-headless',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
-            }
+            'jdk'  => $debian_jdk8,
+            'jre'  => $debian_jre8,
+            'jdk8' => $debian_jdk8,
+            'jre8' => $debian_jre8,
           }
         }
       }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -61,25 +61,9 @@ describe 'java', :type => :class do
     it { should_not contain_exec('update-java-alternatives') }
   end
 
-  context 'select default for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
-    it { should contain_package('java').with_name('openjdk-7-jdk') }
-    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
-  end
-
-  context 'select Oracle JRE for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
-    let(:params) { { 'distribution' => 'oracle-jre' } }
-    it { should contain_package('java').with_name('oracle-j2re1.7') }
-    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
-  end
-
-  context 'select OpenJDK JRE for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
-    let(:params) { { 'distribution' => 'jre' } }
-    it { should contain_package('java').with_name('openjdk-7-jre-headless') }
-    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
-  end
+  # =============================================================================================================================================
+  # Debian: 'lenny', 'squeeze', Ubuntu: 'lucid', 'natty'
+  # =============================================================================================================================================
 
   context 'select default for Debian Squeeze' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
@@ -87,18 +71,42 @@ describe 'java', :type => :class do
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre') }
   end
 
-  context 'select Oracle JRE for Debian Squeeze' do
+  context 'select jdk for Debian Squeeze' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jdk', } }
+    it { should contain_package('java').with_name('openjdk-6-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre') }
+  end
+
+  context 'select jre for Debian Squeeze' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre', } }
+    it { should contain_package('java').with_name('openjdk-6-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
+  end
+
+  context 'select sun-jdk for Debian Squeeze' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'sun-jdk', } }
+    it { should contain_package('java').with_name('sun-java6-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
+  end
+
+  context 'select sun-jre for Debian Squeeze' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { should contain_package('java').with_name('sun-java6-jre') }
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
   end
 
-  context 'select OpenJDK JRE for Debian Squeeze' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
-    let(:params) { { 'distribution' => 'jre', } }
-    it { should contain_package('java').with_name('openjdk-6-jre-headless') }
-    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
+  # =============================================================================================================================================
+  # Debian: 'wheezy', 'jessie', Ubuntu: 'precise','quantal','raring','saucy', 'trusty', 'utopic'
+  # =============================================================================================================================================
+
+  context 'select default for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    it { should contain_package('java').with_name('openjdk-7-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
   end
 
   context 'select random alternative for Debian Wheezy' do
@@ -108,17 +116,123 @@ describe 'java', :type => :class do
     it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set bananafish --jre') }
   end
 
+  context 'select default jdk for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jdk' } }
+    it { should contain_package('java').with_name('openjdk-7-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
+  end
+
+  context 'select default jre for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre' } }
+    it { should contain_package('java').with_name('openjdk-7-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
+  end
+
+  context 'select jdk7 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jdk' } }
+    it { should contain_package('java').with_name('openjdk-7-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
+  end
+
+  context 'select jre7 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre' } }
+    it { should contain_package('java').with_name('openjdk-7-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
+  end
+
+  context 'select jdk8 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jdk8' } }
+    it { should contain_package('java').with_name('openjdk-8-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.8.0-openjdk-amd64 --jre') }
+  end
+
+  context 'select jre8 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'jre8' } }
+    it { should contain_package('java').with_name('openjdk-8-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.8.0-openjdk-amd64 --jre-headless') }
+  end
+
+  context 'select default oracle-jdk for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jdk' } }
+    it { should contain_package('java').with_name('oracle-j2sdk1.7') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2sdk1.7-oracle --jre') }
+  end
+
+  context 'select default oracle-jre for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jre' } }
+    it { should contain_package('java').with_name('oracle-j2re1.7') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
+  end
+
+  context 'select oracle-jdk7 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jdk7' } }
+    it { should contain_package('java').with_name('oracle-j2sdk1.7') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2sdk1.7-oracle --jre') }
+  end
+
+  context 'select oracle-jre7 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jre7' } }
+    it { should contain_package('java').with_name('oracle-j2re1.7') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
+  end
+
+  context 'select oracle-jdk8 for Debian Wheezy (i386)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'i386',} }
+    let(:params) { { 'distribution' => 'oracle-jdk8' } }
+    it { should contain_package('java').with_name('oracle-java8-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jdk-8-oracle-i586 --jre') }
+  end
+
+  context 'select oracle-jre8 for Debian Wheezy (i386)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'i386',} }
+    let(:params) { { 'distribution' => 'oracle-jre8' } }
+    it { should contain_package('java').with_name('oracle-java8-jre') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jre-8-oracle-i586 --jre') }
+  end
+
+  context 'select oracle-jdk8 for Debian Wheezy (amd64)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jdk8' } }
+    it { should contain_package('java').with_name('oracle-java8-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jdk-8-oracle-x64 --jre') }
+  end
+
+  context 'select oracle-jre8 for Debian Wheezy (amd64)' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-jre8' } }
+    it { should contain_package('java').with_name('oracle-java8-jre') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jre-8-oracle-x64 --jre') }
+  end
+
+  # =============================================================================================================================================
+  # Ubuntu: 'vivid'
+  # =============================================================================================================================================
+
   context 'select jdk for Ubuntu Vivid (15.04)' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jdk' } }
     it { should contain_package('java').with_name('openjdk-8-jdk') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.8.0-openjdk-amd64 --jre') }
   end
 
   context 'select jre for Ubuntu Vivid (15.04)' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jre' } }
     it { should contain_package('java').with_name('openjdk-8-jre-headless') }
+    it { should contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.8.0-openjdk-amd64 --jre-headless') }
   end
+
+  # =============================================================================================================================================
 
   context 'select openjdk for Amazon Linux' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64'} }


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-1994

The puppetlabs-java plugin supports different ways to specify the java package to install.

The easiest way obviously is to just include the class:

```
include java
```

which is effectively the same as:

```
include class { 'java':
  distribution => 'jdk'
}
```

On supported platforms, this will install the correct jdk, for example:
* openjdk-6-jdk on lenny, squeeze, lucid and natty
* openjdk-7-jdk on wheezy, jessie, precise, quantal, raring, saucy, trusty, utopic
* openjdk-8-jdk on vivid

In a lot of cases, this is great. But sometimes you want to install another version of the jdk. Lets say 'openjdk-8-jdk' on Ubuntu Trusty. It is still possible by using the package parameter like this:

```
include class { 'java':
  package => 'openjdk-8-jdk'
}
```

But there's a pitfall. While this will correctly install the requested package, it will not set the alternatives, which is one of the major benefits of using the plugin. At this point, you have to investigate. In the plugin code, why it does not set the alternatives, on the filesystem, because you have to figure out the correct alternative name and path. Then you end up with something like this:

```
class { 'java':
  package               => 'oracle-java8-jdk',
  java_alternative      => 'jdk-8-oracle-x64',
  java_alternative_path => '/usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java',
}
```

It would be good, if the plugin could take over this part.
This is why I created this pull request: https://github.com/puppetlabs/puppetlabs-java/pull/116

It allows to install a specific java distribution, e.g. Oracle Java 8 like this:
```
class { 'java':
  distribution => 'oracle-jdk8'
}
```

The following distribution types have been added:

|Distribution|Java Version|Package|
|---|---|---|
|jdk|OpenJDK 7|openjdk-7-jdk|
|jre|OpenJDK 7|openjdk-7-jre-headless|
|jdk7|OpenJDK 7|openjdk-7-jdk|
|jre7|OpenJDK 7|openjdk-7-jre-headless|
|jdk8|OpenJDK 8|openjdk-8-jdk|
|jre8|OpenJDK 8|openjdk-8-jre-headless|
|oracle-jdk|Oracle Java 7|oracle-java7-jdk|
|oracle-jre|Oracle Java 7|oracle-java7-jre|
|oracle-jdk7|Oracle Java 7|oracle-java7-jdk|
|oracle-jre7|Oracle Java 7|oracle-java7-jre|
|oracle-jdk8|Oracle Java 8|oracle-java8-jdk|
|oracle-jre8|Oracle Java 8|oracle-java8-jre|

## Infos

* At the moment this only affects Debian ('wheezy', 'jessie', 'precise','quantal','raring','saucy', 'trusty', 'utopic').
* I have added tests, to verify that this change will not introduce any regressions.
