### PR TITLE
add two facts: libjvm and java executable paths

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,8 @@ The java module includes a few facts to describe the version of Java installed o
 * `java_major_version`: The major version of Java.
 * `java_patch_level`: The patch level of Java.
 * `java_version`: The full Java version string.
+* `java_default_home`: The absolute path to the java system home directory (only available on Linux). For instance, the `java` executable's path would be `${::java_default_home}/jre/bin/java`. This is slightly different from the "standard" JAVA_HOME environment variable.
+* `java_libjvm_path`: The absolute path to the directory containing the shared library `libjvm.so` (only available on Linux). Useful for setting `LD_LIBRARY_PATH` or configuring the dynamic linker.
 
 **Note:** The facts return `nil` if Java is not installed on the system.
 

--- a/lib/facter/java_default_home.rb
+++ b/lib/facter/java_default_home.rb
@@ -1,0 +1,21 @@
+# Fact: java_default_home
+#
+# Purpose: get absolute path of java system home
+#
+# Resolution:
+#   Uses `readlink` to resolve the path of `/usr/bin/java` then returns subsubdir
+#
+# Caveats:
+#   Requires readlink
+#
+# Notes:
+#   None
+Facter.add(:java_default_home) do
+  confine :kernel => 'Linux'
+  setcode do
+    if Facter::Util::Resolution.which('readlink')
+      java_bin = Facter::Util::Resolution.exec('readlink -e /usr/bin/java').strip
+      java_default_home = File.dirname(File.dirname(File.dirname(java_bin)))
+    end
+  end
+end

--- a/lib/facter/java_libjvm_path.rb
+++ b/lib/facter/java_libjvm_path.rb
@@ -1,0 +1,25 @@
+# Fact: java_libjvm_path
+#
+# Purpose: get path to libjvm.so
+#
+# Resolution:
+#   Lists file in java default home and searches for the file
+#
+# Caveats:
+#   Needs to list files recursively. Returns the first match
+#
+# Notes:
+#   None
+Facter.add(:java_libjvm_path) do
+  confine :kernel => "Linux"
+  setcode do
+    java_default_home = Facter.value(:java_default_home)
+    java_libjvm_file = Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")
+    if java_libjvm_file.nil? || java_libjvm_file.empty?
+      nil
+    else
+      File.dirname(java_libjvm_file[0])
+    end
+  end
+end
+

--- a/spec/unit/facter/java_default_home_spec.rb
+++ b/spec/unit/facter/java_default_home_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+    Facter.fact(:kernel).stubs(:value).returns('Linux')
+  }
+
+  describe "java_default_home" do
+    context 'returns java home path when readlink present' do
+      it do
+        java_path_output = <<-EOS
+/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+        EOS
+        Facter::Util::Resolution.expects(:which).with("readlink").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("readlink -e /usr/bin/java").returns(java_path_output)
+        Facter.value(:java_default_home).should == "/usr/lib/jvm/java-7-openjdk-amd64"
+      end
+    end
+
+    context 'returns nil when readlink not present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("readlink").at_least(1).returns(false)
+        Facter.value(:java_default_home).should be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/facter/java_libjvm_path_spec.rb
+++ b/spec/unit/facter/java_libjvm_path_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+    Facter.fact(:kernel).stubs(:value).returns('Linux')
+    java_default_home = '/usr/lib/jvm/java-8-openjdk-amd64'
+    Facter.fact(:java_default_home).stubs(:value).returns(java_default_home)
+    Dir.stubs(:glob).with("#{java_default_home}/jre/lib/**/libjvm.so").returns( ['/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so'])
+  }
+
+  describe "java_libjvm_path" do
+    context 'returns libjvm path' do
+      context 'on Linux' do
+        it do
+          Facter.value(:java_libjvm_path).should == "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It's complicated to automatically determine the location of `libjvm.so`. Neither openjdk nor oracle packages provide hints for `ld.so.conf.d`. The path to the java executable is just a byproduct than I thought could be useful.