### PR TITLE
Support for provided jdk/jre package files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,17 @@
 #    alternative is actually enabled, this is required to ensure the
 #    correct JVM is enabled.
 #
+#  [*provider*]
+#    The name of the package provider (e.g. rpm) to be used for a manual
+#    package installation.
+#    Requires a source (path) for a compatible package file.
+#
+#  [*source*]
+#    The path to the package file (e.g. /mypath/jdk-7u79-linux-x64.rpm).
+#    Must be compatible with the specified provider.
+#    Don't forget to set java_alternative and java_alternative_path, since
+#    manually installed packages usually do not provide them.
+#
 # Actions:
 #
 # Requires:
@@ -42,7 +53,9 @@ class java(
   $version               = 'present',
   $package               = undef,
   $java_alternative      = undef,
-  $java_alternative_path = undef
+  $java_alternative_path = undef,
+  $provider              = undef,
+  $source                = undef,
 ) {
   include java::params
 
@@ -90,8 +103,10 @@ class java(
   anchor { 'java::begin:': }
   ->
   package { 'java':
-    ensure => $version,
-    name   => $use_java_package_name,
+    ensure   => $version,
+    name     => $use_java_package_name,
+    provider => $provider,
+    source   => $source,
   }
   ->
   class { 'java::config': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,9 +70,12 @@ class java(
     fail("Java distribution ${distribution} is not supported.")
   }
 
-  $use_java_package_name = $package ? {
-    undef   => $default_package_name,
-    default => $package,
+  ## Ignores package when provider and source are specified.
+  if !($provider and $source) {
+    $use_java_package_name = $package ? {
+      undef   => $default_package_name,
+      default => $package,
+    }
   }
 
   ## If $java_alternative is set, use that.


### PR DESCRIPTION
The goal is to enable the installation of a previously downloaded jdk/jre package, such as .deb or .rpm. Some versions which are still unsupported can be installed (e.g. OracleJDK 1.7 on CentOS 7) by using the package file (e.g. jdk-7u79-linux-x64.rpm).

Sure you can use the package resource directly instead of the java class on you puppet script. But the idea is to wrap it, so you could easily switch the jdk/jre distro by changing attributes within hiera.yaml, for example.