### PR TITLE
Install update-java-alternatives on Debian for the java::config class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,14 @@ class java(
     default    => '--jre'
   }
 
+  if $::osfamily == 'Debian' {
+    # Needed for update-java-alternatives
+    package { 'java-common':
+      ensure => present,
+      before => Class['java::config'],
+    }
+  }
+
   anchor { 'java::begin:': }
   ->
   package { 'java':


### PR DESCRIPTION
As is the `java::config` class will fail when installed on a fresh Debian install.