### PR TITLE
Add support for installing Oracle JDK, JRE 6, 7 and 8 on RedHat.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     stdlib: http://github.com/puppetlabs/puppetlabs-stdlib.git
+    archive: https://github.com/puppet-community/puppet-archive.git
   symlinks:
     java: "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+##2015-07-07 - Supported Release 1.4.0
+###Summary
+This release adds several new features, bugfixes, documentation updates, and test improvements.
+
+####Features:
+- Puppet 4 support and testing
+- Adds support for several Operating Systems
+  - Ubuntu 15.04
+  - OpenBSD 5.6, 5.7
+  - Fedora 20, 21, 22
+
+####Bugfixes:
+- Fixes java_version fact to work on large systems. (MODULES-1749)
+- Improves maintainability of java_version fact.
+- Fixes java package names on Fedora 21+.
+- Fixes java install problems on Puppet 3.7.5 - 3.8.1 (PUP-4520)
+- Fixes create-java-alternatives commands on RedHat distros.
+- Fixes bug with Debian systems missing java-common package.
+
 ##2015-01-20 - Supported Release 1.3.0
 ###Summary
 This release adds 3 new facts for determining Java version, adds RHEL alternatives support, adds utopic support, and fixes the flag for `update-java-alternatives` when installed from a headless pacakge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2015-07-16 - Supported Release 1.4.1
+### Summary
+This release updates the metadata for the upcoming release of PE and update params for OEL to match metadata
+
+#### Bugfixes:
+- Add missing OEL to params
+
 ##2015-07-07 - Supported Release 1.4.0
 ###Summary
 This release adds several new features, bugfixes, documentation updates, and test improvements.

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@
 
 ##Overview
 
-Installs the correct Java package on various platforms. 
+Installs the correct Java package on various platforms.
 
 ##Module Description
 
@@ -34,6 +34,32 @@ class { 'java':
 }
 ~~~
 
+The type java::oracle will install one or more versions of Oracle JavaSE.
+
+If you want to install Oracle's version of Java SE call on the type java::oracle
+with the javaSE and version parameters:
+
+~~~
+java::oracle { 'jdk7' :
+  version => '7'
+  javaSE  => 'jdk'
+}
+~~~
+
+You can install another version of Oracle JavaSE calling java::oracle a second
+time.
+
+~~~
+java::oracle { 'jdk8' :
+  version => '8'
+  javaSE  => 'jdk'
+}
+~~~
+
+Calling java::oracle will not set JAVA_HOME or set a default JavaSE for the
+system.  You must be aware of which JavaSE is the default or set JAVA_HOME for
+your applications.
+
 ##Reference
 
 ###Classes
@@ -41,6 +67,7 @@ class { 'java':
 ####Public classes
 
 * `java`: Installs and manages the Java package.
+* `java::oracle`: Installs and manages the official Oracle Java packages.
 
 ####Private classes
 
@@ -65,7 +92,7 @@ Valid option: String. Default: OS and distribution dependent defaults on *deb sy
 
 #####`package`
 Specifies the name of the Java package. This is configurable in case you want to install a non-standard Java package. If not set, the module will install the appropriate package for the `distribution` parameter and target platform. If you set `package`, the `distribution` parameter will do nothing.  
-Valid option: String. Default: undef. 
+Valid option: String. Default: undef.
 
 #####`version`
 Sets the version of Java to install, if you want to ensure a particular version.  
@@ -84,7 +111,7 @@ The java module includes a few facts to describe the version of Java installed o
 
 ##Limitations
 
-This module cannot guarantee installation of Java versions that are not available on  platform repositories. 
+This module cannot guarantee installation of Java versions that are not available on  platform repositories.
 
 This module only manages a singular installation of Java, meaning it is not possible to manage e.g. OpenJDK 7, Oracle Java 7 and Oracle Java 8 in parallel on the same system.
 
@@ -101,7 +128,7 @@ OpenJDK is supported on:
 * Debian 6, 7
 * Ubuntu 10.04, 12.04, 14.04
 * Solaris 11
-* SLES 11 SP1, 12 
+* SLES 11 SP1, 12
 * OpenBSD 5.6, 5.7
 
 Sun Java is supported on:  

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,14 @@ class java(
     default    => '--jre'
   }
 
+  if $::osfamily == 'Debian' {
+    # Needed for update-java-alternatives
+    package { 'java-common':
+      ensure => present,
+      before => Class['java::config'],
+    }
+  }
+
   anchor { 'java::begin:': }
   ->
   package { 'java':

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -1,0 +1,215 @@
+# Defined Type java::oracle
+#
+# Description
+# Installs Oracle Java. By using this module you agree to the Oracle licensing
+# agreement.
+#
+# Install one or more versions of Oracle Java.
+#
+# uses the following to download the package and automatically accept
+# the licensing terms.
+# wget --no-cookies --no-check-certificate --header \
+# "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \
+# "http://download.oracle.com/otn-pub/java/jdk/8u25-b17/jre-8u25-linux-x64.tar.gz"
+#
+# Parameters
+# [*version*]
+# Version of Java to install
+#
+# [*javaSE*]
+# Type of Java Standard Edition to install, jdk or jre.
+#
+# [*ensure*]
+# Install or remove the package.
+#
+# [*baseUrl*]
+# Official Oracle URL to download binaries from.
+#
+# Variables
+# [*releaseMajor*]
+# Major version release number for JavaSE. Used to construct download URL.
+#
+# [*releaseMinor*]
+# Minor version release number for JavaSE. Used to construct download URL.
+#
+# [*installPath*]
+# Base install path for specified version of JavaSE. Used to determine if JavaSE
+# has already been installed.
+#
+# [*packageType*]
+# Type of installation package for specified version of JavaSE. JavaSE 6 comes
+# in a few installation package flavors and we need to account for them.
+#
+# [*os*]
+# Oracle JavaSE OS type.
+#
+# [*destinationDir*]
+# Destination directory to save JavaSE installer to.  Usually /tmp on Linux and
+# C:\TEMP on Windows.
+#
+# [*createsPath*]
+# Fully qualified path to JavaSE after it is installed. Used to determine if
+# JavaSE is already installed.
+#
+# [*arch*]
+# Oracle JavaSE architecture type.
+#
+# [*packageName*]
+# Name of the JavaSE installation package to download from Oracle's website.
+#
+# [*installCommand*]
+# Installation command used to install Oracle JavaSE. Installation commands
+# differ by packageType. 'bin' types are installed via shell command. 'rpmbin'
+# types have the rpms extracted and then foricibly installed. 'rpm' types are
+# foricibly installed.
+#
+# [*url*]
+# Full URL, including baseUrl, releaseMajor, releaseMinor and packageName, to
+# download the Oracle JavaSE installer.
+#
+# ### Author
+# mike@marseglia.org
+#
+define java::oracle (
+  $ensure       = 'present',
+  $version      = '7',
+  $javaSE       = 'jdk',
+  $baseUrl      = 'http://download.oracle.com/otn-pub/java/jdk/',
+) {
+
+  include ::archive
+
+  ensure_resource('class', 'stdlib')
+
+  # validate java Standard Edition to download
+  if $javaSE !~ /(jre|jdk)/ {
+    fail('Java SE must be either jre or jdk.')
+  }
+
+  # determine oracle Java major and minor version
+  case $version {
+    '6' : {
+      $releaseMajor = '6u45'
+      $releaseMinor = 'b06'
+      $installPath = "${javaSE}1.6.0_45"
+    }
+    '7' : {
+      $releaseMajor = '7u80'
+      $releaseMinor = 'b15'
+      $installPath = "${javaSE}1.7.0_80"
+    }
+    '8' : {
+      $releaseMajor = '8u51'
+      $releaseMinor = 'b16'
+      $installPath = "${javaSE}1.8.0_51"
+    }
+    default : {
+      $releaseMajor = '8u51'
+      $releaseMinor = 'b16'
+      $installPath = "${javaSE}1.8.0_51"
+    }
+  }
+
+  # determine package type (exe/tar/rpm), destination directory based on OS
+  case downcase($::kernel) {
+    'linux' : {
+      case downcase($::osfamily) {
+        'redhat', 'centos' : {
+          if $version == '6' {
+            $packageType = 'rpmbin'
+          } else {
+            $packageType = 'rpm'
+          }
+        }
+        default : {
+          fail ("OS ${::osfamily} unsupported platform.") }
+      }
+
+      $os = 'linux'
+      $destinationDir = '/tmp/'
+      $createsPath = "/usr/java/${installPath}"
+    }
+    default : {
+      fail ( "Kernel ${::kernel} unsupported platform." ) }
+  }
+
+  # determine java architecture type
+  case $::architecture {
+    'i386' : { $arch = 'i586' }
+    'x86_64' : { $arch = 'x64' }
+    default : {
+      fail ("Architecture ${::architecture} unsupported platform.")
+    }
+  }
+
+  # following are based on this example:
+  # http://download.oracle.com/otn/java/jdk/7u80-b15/jre-7u80-linux-i586.rpm
+  #
+  # JaveSE 6 distributed in .bin format
+  # http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-i586-rpm.bin
+  # http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-i586.bin
+  # package name to download from Oracle's website
+  case $packageType {
+    'bin' : {
+      $packageName = "${javaSE}-${releaseMajor}-${os}-${arch}.bin"
+    }
+    'rpmbin' : {
+      $packageName = "${javaSE}-${releaseMajor}-${os}-${arch}-rpm.bin"
+    }
+    'rpm' : {
+      $packageName = "${javaSE}-${releaseMajor}-${os}-${arch}.rpm"
+    }
+    default : {
+      $packageName = "${javaSE}-${releaseMajor}-${os}-${arch}.rpm"
+    }
+  }
+
+  # full path to the installer
+  $destination = "${destinationDir}${packageName}"
+  notice ("Destination is ${destination}")
+
+  case $packageType {
+    'bin' : {
+      $installCommand = "sh ${destination}"
+    }
+    'rpmbin' : {
+      $installCommand = "sh ${destination} -x; rpm --force -iv sun*.rpm; rpm --force -iv ${javaSE}*.rpm"
+    }
+    'rpm' : {
+      $installCommand = "rpm --force -iv ${destination}"
+    }
+    default : {
+      $installCommand = "rpm -iv ${destination}"
+    }
+  }
+
+  # full URL to download
+  $url = "${baseUrl}${releaseMajor}-${releaseMinor}/${packageName}"
+
+  case $ensure {
+    'present' : {
+      archive { $destination :
+        ensure  => present,
+        source  => $url,
+        cleanup => false,
+        cookie  => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+      }->
+      case downcase($::kernel) {
+        'linux' : {
+          exec { "Install Oracle JavaSE ${javaSE} ${version}" :
+            path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+            command => $installCommand,
+            creates => $createsPath,
+          }
+        }
+        default : {
+          fail ("Install for operating system ${::kernel} unsupported platform")
+        }
+      }
+    }
+    default : {
+      notice ("Action ${ensure} not supported.")
+    }
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class java::params {
   case $::osfamily {
     'RedHat': {
       case $::operatingsystem {
-        'RedHat', 'CentOS', 'OracleLinux', 'Scientific': {
+        'RedHat', 'CentOS', 'OracleLinux', 'Scientific', 'OEL': {
           if (versioncmp($::operatingsystemrelease, '5.0') < 0) {
             $jdk_package = 'java-1.6.0-sun-devel'
             $jre_package = 'java-1.6.0-sun'

--- a/metadata.json
+++ b/metadata.json
@@ -86,6 +86,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"},
+    {"name":"puppet-community/puppet-archive","version_requirement":"0.3.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.0.0 < 2015.3.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppet",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-java",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "puppetlabs",
   "summary": "Installs the correct Java package on various platforms.",
   "license": "Apache-2.0",
@@ -78,7 +78,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 2015.3.0"
     },
     {
       "name": "puppet",

--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 2015.3.0"
     },
     {
       "name": "puppet",

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,14 @@
       ]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "20",
+        "21",
+        "22"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-java",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "puppetlabs",
   "summary": "Installs the correct Java package on various platforms.",
   "license": "Apache-2.0",
@@ -78,14 +78,14 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"}
   ]
 }

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe 'java::oracle', :type => :define do
+    context 'On RedHat 64-bit' do
+      let(:facts) { {:kernel => 'Linux', :architecture => 'x86_64', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+
+      context 'Oracle Java SE 6 JDK' do
+      let(:params) { {:ensure => 'present', :version => '6', :javaSE => 'jdk'} }
+      let :title do 'jdk6' end
+        it { should contain_archive('/tmp/jdk-6u45-linux-x64-rpm.bin')}
+        it { should contain_exec('Install Oracle JavaSE jdk 6').with_command('sh /tmp/jdk-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
+      end
+
+      context 'Oracle Java SE 7 JDK' do
+        let(:params) { {:ensure => 'present', :version => '7', :javaSE => 'jdk'} }
+        let :title do 'jdk7' end
+          it { should contain_archive('/tmp/jdk-7u80-linux-x64.rpm')}
+          it { should contain_exec('Install Oracle JavaSE jdk 7').with_command('rpm --force -iv /tmp/jdk-7u80-linux-x64.rpm') }
+      end
+
+    context 'Oracle Java SE 8 JDK' do
+      let(:params) { {:ensure => 'present', :version => '8', :javaSE => 'jdk'} }
+      let :title do 'jdk8' end
+        it { should contain_archive('/tmp/jdk-8u51-linux-x64.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jdk 8').with_command('rpm --force -iv /tmp/jdk-8u51-linux-x64.rpm') }
+    end
+
+    context 'Oracle Java SE 6 JRE' do
+      let(:params) { {:ensure => 'present', :version => '6', :javaSE => 'jre'} }
+      let :title do 'jre6' end
+        it { should contain_archive('/tmp/jre-6u45-linux-x64-rpm.bin')}
+        it { should contain_exec('Install Oracle JavaSE jre 6').with_command('sh /tmp/jre-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
+    end
+
+    context 'Oracle Java SE 7 JRE' do
+      let(:params) { {:ensure => 'present', :version => '7', :javaSE => 'jre'} }
+      let :title do 'jre7' end
+        it { should contain_archive('/tmp/jre-7u80-linux-x64.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jre 7').with_command('rpm --force -iv /tmp/jre-7u80-linux-x64.rpm') }
+    end
+
+    context 'select Oracle Java SE 8 JRE' do
+      let(:params) { {:ensure => 'present', :version => '8', :javaSE => 'jre'} }
+      let :title do 'jre8' end
+        it { should contain_archive('/tmp/jre-8u51-linux-x64.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jre 8').with_command('rpm --force -iv /tmp/jre-8u51-linux-x64.rpm') }
+    end
+
+  end
+
+  context 'On RedHat 32-bit' do
+    let(:facts) { {:kernel => 'Linux', :architecture => 'i386', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+
+    context 'select Oracle Java SE 6 JDK on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '6', :javaSE => 'jdk'} }
+      let :title do 'jdk6' end
+        it { should contain_archive('/tmp/jdk-6u45-linux-i586-rpm.bin')}
+        it { should contain_exec('Install Oracle JavaSE jdk 6').with_command('sh /tmp/jdk-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
+    end
+
+    context 'select Oracle Java SE 7 JDK on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '7', :javaSE => 'jdk'} }
+      let :title do 'jdk7' end
+        it { should contain_archive('/tmp/jdk-7u80-linux-i586.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jdk 7').with_command('rpm --force -iv /tmp/jdk-7u80-linux-i586.rpm') }
+    end
+
+    context 'select Oracle Java SE 8 JDK on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '8', :javaSE => 'jdk'} }
+      let :title do 'jdk8' end
+        it { should contain_archive('/tmp/jdk-8u51-linux-i586.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jdk 8').with_command('rpm --force -iv /tmp/jdk-8u51-linux-i586.rpm') }
+    end
+
+    context 'select Oracle Java SE 6 JRE on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '6', :javaSE => 'jre'} }
+      let :title do 'jdk6' end
+        it { should contain_archive('/tmp/jre-6u45-linux-i586-rpm.bin')}
+        it { should contain_exec('Install Oracle JavaSE jre 6').with_command('sh /tmp/jre-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
+    end
+
+    context 'select Oracle Java SE 7 JRE on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '7', :javaSE => 'jre'} }
+      let :title do 'jdk7' end
+        it { should contain_archive('/tmp/jre-7u80-linux-i586.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jre 7').with_command('rpm --force -iv /tmp/jre-7u80-linux-i586.rpm') }
+    end
+
+    context 'select Oracle Java SE 8 JRE on RedHat family, 32-bit' do
+      let(:params) { {:ensure => 'present', :version => '8', :javaSE => 'jre'} }
+      let :title do 'jdk8' end
+        it { should contain_archive('/tmp/jre-8u51-linux-i586.rpm')}
+        it { should contain_exec('Install Oracle JavaSE jre 8').with_command('rpm --force -iv /tmp/jre-8u51-linux-i586.rpm') }
+    end
+  end
+
+  describe 'incompatible OSs' do
+    [
+      {
+        # C14706
+        :osfamily               => 'windows',
+        :operatingsystem        => 'windows',
+        :operatingsystemrelease => '8.1',
+        :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)',
+      },
+      {
+        # C14707
+        :osfamily               => 'Darwin',
+        :operatingsystem        => 'Darwin',
+        :operatingsystemrelease => '13.3.0',
+        :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)',
+      },
+      {
+        # C14708
+        :osfamily               => 'AIX',
+        :operatingsystem        => 'AIX',
+        :operatingsystemrelease => '7100-02-00-000',
+        :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)',
+      },
+      {
+        # C14708
+        :osfamily               => 'AIX',
+        :operatingsystem        => 'AIX',
+        :operatingsystemrelease => '6100-07-04-1216',
+        :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)',
+      },
+      {
+        # C14708
+        :osfamily               => 'AIX',
+        :operatingsystem        => 'AIX',
+        :operatingsystemrelease => '5300-12-01-1016',
+        :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)',
+      },
+    ].each do |facts|
+      let(:facts) { facts }
+      let :title do 'jdk' end
+      it "should fail on #{facts[:operatingsystem]} #{facts[:operatingsystemrelease]}" do
+        expect { catalogue }.to raise_error Puppet::Error, /unsupported platform/
+      end
+    end
+  end
+end

--- a/tests/oracle.pp
+++ b/tests/oracle.pp
@@ -1,0 +1,5 @@
+java::oracle { 'jdk6' :
+  ensure      => 'present',
+  version     => '6',
+  javaSE      => 'jdk',
+}


### PR DESCRIPTION
Hello,

  We needed support for Oracle Java and I added support for it here.  I have tested this on CentOS and it seems to work OK.

  Could you please take a look?  It would really help if Puppet Labs officially supported Oracle Java.

Thank you