### PR TITLE
Fix rspec deprecation warnings. .should -> expect().to

### DIFF
--- a/spec/unit/facter/java_major_version_spec.rb
+++ b/spec/unit/facter/java_major_version_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact do
         Facter.fact(:java_version).stubs(:value).returns('1.7.0_71')
       end
       it do
-        Facter.fact(:java_major_version).value.should == "7"
+        expect(Facter.fact(:java_major_version).value).to eq("7")
       end
     end
 
@@ -20,7 +20,7 @@ describe Facter::Util::Fact do
         Facter.fact(:java_version).stubs(:value).returns(nil)
       end
       it do
-        Facter.fact(:java_major_version).value.should be_nil
+        expect(Facter.fact(:java_major_version).value).to be_nil
       end
     end
   end

--- a/spec/unit/facter/java_patch_level_spec.rb
+++ b/spec/unit/facter/java_patch_level_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Util::Fact do
           Facter.fact(:java_version).stubs(:value).returns('1.7.0_71')
         end
         it do
-          Facter.fact(:java_patch_level).value.should == "71"
+          expect(Facter.fact(:java_patch_level).value).to eq("71")
         end
       end
     end
@@ -23,7 +23,7 @@ describe Facter::Util::Fact do
           Facter.fact(:java_version).stubs(:value).returns(nil)
         end
         it do
-          Facter.fact(:java_patch_level).value.should be_nil
+          expect(Facter.fact(:java_patch_level).value).to be_nil
         end
       end
     end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -20,7 +20,7 @@ OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
           EOS
           Facter::Util::Resolution.expects(:which).with("java").returns('/usr/local/jdk-1.7.0/jre/bin/java')
           Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
-          Facter.value(:java_version).should == "1.7.0_71"
+          expect(Facter.value(:java_version)).to eq("1.7.0_71")
         end
       end
       context 'on other systems' do
@@ -35,7 +35,7 @@ Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
           EOS
           Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
-          Facter.value(:java_version).should == "1.7.0_71"
+          expect(Facter.value(:java_version)).to eq("1.7.0_71")
         end
       end
     end
@@ -48,7 +48,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         let(:facts) { {:operatingsystem => 'OpenBSD'} }
         it do
           Facter::Util::Resolution.stubs(:exec)
-          Facter.value(:java_version).should be_nil
+          expect(Facter.value(:java_version)).to be_nil
         end
       end
       context 'on other systems' do
@@ -58,7 +58,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         let(:facts) { {:operatingsystem => 'MyOS'} }
         it do
           Facter::Util::Resolution.expects(:which).at_least(1).with("java").returns(false)
-          Facter.value(:java_version).should be_nil
+          expect(Facter.value(:java_version)).to be_nil
         end
       end
     end


### PR DESCRIPTION
Fixes
```
Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is 
deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from 
/my/vagrant/puppet/modules/upstream/java/spec/unit/facter/java_major_version_spec.rb:14:in `block (4 levels) in <top (required)>'.
```