### PR TITLE
(MODULES-2637) Checks java actually installed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  # declare an exclusion filter for the tests using with_env on facter 1.6, as the function is not available on 1.6
+  c.filter_run_excluding :with_env => true if Facter.version =~ /^1\.6\./
+end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Util::Fact do
 
   describe "java_version" do
     context 'returns java version when java present' do
-      context 'on OpenBSD' do
+      context 'on OpenBSD', :with_env => true do
         before do
           Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
         end
@@ -41,7 +41,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
     end
 
     context 'returns nil when java not present' do
-      context 'on OpenBSD' do
+      context 'on OpenBSD', :with_env => true do
         before do
           Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
         end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -23,6 +23,22 @@ OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
           expect(Facter.value(:java_version)).to eq("1.7.0_71")
         end
       end
+      context 'on Darwin' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("Darwin")
+        end
+        let(:facts) { {:operatingsystem => 'Darwin'} }
+        it do
+          java_version_output = <<-EOS
+java version "1.7.0_71"
+Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
+Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
+          EOS
+          Facter::Util::Resolution.expects(:exec).with("/usr/libexec/java_home --failfast 2>&1").returns("/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home")
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter.value(:java_version).should == "1.7.0_71"
+        end
+      end
       context 'on other systems' do
         before do
           Facter.fact(:operatingsystem).stubs(:value).returns("MyOS")
@@ -49,6 +65,16 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         it do
           Facter::Util::Resolution.stubs(:exec)
           expect(Facter.value(:java_version)).to be_nil
+        end
+      end
+      context 'on Darwin' do
+        before do
+          Facter.fact(:operatingsystem).stubs(:value).returns("Darwin")
+        end
+        let(:facts) { {:operatingsystem => 'Darwin'} }
+        it do
+          Facter::Util::Resolution.expects(:exec).at_least(1).with("/usr/libexec/java_home --failfast 2>&1").returns('Unable to find any JVMs matching version "(null)".')
+          Facter.value(:java_version).should be_nil
         end
       end
       context 'on other systems' do


### PR DESCRIPTION
The other method for running which java doesn't work on OSX, as java is installed as an empty shim when not installed in the base OSX image:

```
vagrant:~ vagrant$ java
No Java runtime present, requesting install.
vagrant:~ vagrant$ /usr/libexec/java_home --failfast
Unable to find any JVMs matching version "(null)".
vagrant:~ vagrant$
```

We can use the `/usr/libexec/java_home --failfast` command to check if
java is actually present first.

Originally-by: Peter Souter <peter.souter@puppetlabs.com>