### PR TITLE
Can now pass options to package provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,10 @@
 #    The name of the java package. This is configurable in case a non-standard
 #    java package is desired.
 #
+#  [*package_options*]
+#    Array of strings to pass installation options to the 'package' Puppet resource.
+#    Options available depend on the 'package' provider for the target OS.
+#
 #  [*java_alternative*]
 #    The name of the java alternative to use on Debian systems.
 #    "update-java-alternatives -l" will show which choices are available.
@@ -41,12 +45,17 @@ class java(
   $distribution          = 'jdk',
   $version               = 'present',
   $package               = undef,
+  $package_options       = undef,
   $java_alternative      = undef,
   $java_alternative_path = undef
 ) {
   include java::params
 
   validate_re($version, 'present|installed|latest|^[.+_0-9a-zA-Z:-]+$')
+  
+  if $package_options != undef {
+    validate_array($package_options)
+  }
 
   if has_key($java::params::java, $distribution) {
     $default_package_name     = $java::params::java[$distribution]['package']
@@ -98,8 +107,9 @@ class java(
   anchor { 'java::begin:': }
   ->
   package { 'java':
-    ensure => $version,
-    name   => $use_java_package_name,
+    ensure          => $version,
+    install_options => $package_options,
+    name            => $use_java_package_name,
   }
   ->
   class { 'java::config': }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -47,6 +47,13 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre' } }
     it { should contain_package('java').with_name('java-1.8.0-openjdk') }
   end
+  
+  context 'select passed value for Fedora 21 with yum option' do
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21'} }
+    let(:params) { { 'distribution' => 'jre' } }
+    let(:params) { { 'package_options'  => ['--skip-broken'] } }
+    it { should contain_package('java') }
+  end
 
   context 'select passed value for Centos 5.3' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3'} }


### PR DESCRIPTION
In order to support edge cases where yum, apt-get or whichever package provider is supported by Puppet's 'package' resource, you can now pass an array of string options as you would normally with 'install_options'.
This is done with a new class parameter named 'package_options', for example:
```puppet
class { 'java':
  package               => 'jdk-custom',
  package_options  => ['--nogpgcheck']
}
```