### PR TITLE
Use java 8 as the default on RHEL > 7.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,9 +24,13 @@ class java::params {
             $jdk_package = 'java-1.6.0-openjdk-devel'
             $jre_package = 'java-1.6.0-openjdk'
           }
-          else {
+          elsif (versioncmp($::operatingsystemrelease, '7.1') < 0) {
             $jdk_package = 'java-1.7.0-openjdk-devel'
             $jre_package = 'java-1.7.0-openjdk'
+          }
+          else {
+            $jdk_package = 'java-1.8.0-openjdk-devel'
+            $jre_package = 'java-1.8.0-openjdk'
           }
         }
         'Fedora': {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -12,6 +12,11 @@ describe 'java', :type => :class do
     it { should contain_package('java').with_name('java-1.7.0-openjdk-devel') }
   end
 
+  context 'select openjdk for Centos 7.1.1503' do
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503'} }
+    it { should contain_package('java').with_name('java-1.8.0-openjdk-devel') }
+  end
+
   context 'select openjdk for Centos 6.2' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.2'} }
     it { should contain_package('java').with_name('java-1.6.0-openjdk-devel') }


### PR DESCRIPTION
Starting in 7.1, RHEL ships OpenJDK 8.

http://vault.centos.org/7.1.1503/os/x86_64/Packages/