### PR TITLE
Update java package for SLES 11.4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -164,15 +164,15 @@ class java::params {
     'Suse': {
       case $::operatingsystem {
         'SLES': {
-          case $::operatingsystemmajrelease{
-            default: {
-              $jdk_package = 'java-1_6_0-ibm-devel'
-              $jre_package = 'java-1_6_0-ibm'
-            }
-            '12': {
-              $jdk_package = 'java-1_7_0-openjdk-devel'
-              $jre_package = 'java-1_7_0-openjdk'
-            }
+          if (versioncmp($::operatingsystemrelease, '12') >= 0) {
+            $jdk_package = 'java-1_7_0-openjdk-devel'
+            $jre_package = 'java-1_7_0-openjdk'
+          } elsif (versioncmp($::operatingsystemrelease, '11.4') >= 0) {
+            $jdk_package = 'java-1_7_0-ibm-devel'
+            $jre_package = 'java-1_7_0-ibm'
+          } else {
+            $jdk_package = 'java-1_6_0-ibm-devel'
+            $jre_package = 'java-1_6_0-ibm'
           }
         }
         'OpenSuSE': {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -170,6 +170,21 @@ describe 'java', :type => :class do
     it { is_expected.to contain_package('java').with_name('java-1_7_0-openjdk-devel')}
   end
 
+  context 'select default for SLES 11.3' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3'}}
+    it { should contain_package('java').with_name('java-1_6_0-ibm-devel')}
+  end
+
+  context 'select default for SLES 11.4' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4'}}
+    it { should contain_package('java').with_name('java-1_7_0-ibm-devel')}
+  end
+
+  context 'select default for SLES 12.1' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12'}}
+    it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
+  end
+
   context 'select jdk for OpenBSD' do
     let(:facts) { {:osfamily => 'OpenBSD'} }
     it { is_expected.to contain_package('java').with_name('jdk') }


### PR DESCRIPTION
As of SLES 11.4, Java 1.6 has been deprecated in favor of 1.7:
https://www.suse.com/releasenotes/x86_64/SLE-SDK/11-SP4/#fate-318121