### PR TITLE
custom archive type needs extract_path

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -188,10 +188,11 @@ define java::oracle (
   case $ensure {
     'present' : {
       archive { $destination :
-        ensure  => present,
-        source  => "${oracle_url}${release_major}-${release_minor}/${package_name}",
-        cleanup => false,
-        cookie  => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+        ensure       => present,
+        source       => "${oracle_url}${release_major}-${release_minor}/${package_name}",
+        cleanup      => false,
+        extract_path => '/tmp',
+        cookie       => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
       }->
       case $::kernel {
         'Linux' : {


### PR DESCRIPTION
archive type's extract_path doesn't have a default parameter and needs to be set (see https://github.com/voxpupuli/puppet-archive/blob/master/lib/puppet/type/archive.rb#L71-L78). If I don't set one I get the following error when trying to use this module:

Error: Failed to apply catalog: No title provided and :file is not a valid resource reference