### PR TITLE
Update SLES 11sp4 packages to Java 1.7.1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -168,8 +168,8 @@ class java::params {
             $jdk_package = 'java-1_7_0-openjdk-devel'
             $jre_package = 'java-1_7_0-openjdk'
           } elsif (versioncmp($::operatingsystemrelease, '11.4') >= 0) {
-            $jdk_package = 'java-1_7_0-ibm-devel'
-            $jre_package = 'java-1_7_0-ibm'
+            $jdk_package = 'java-1_7_1-ibm-devel'
+            $jre_package = 'java-1_7_1-ibm'
           } else {
             $jdk_package = 'java-1_6_0-ibm-devel'
             $jre_package = 'java-1_6_0-ibm'

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -177,7 +177,7 @@ describe 'java', :type => :class do
 
   context 'select default for SLES 11.4' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4'}}
-    it { should contain_package('java').with_name('java-1_7_0-ibm-devel')}
+    it { should contain_package('java').with_name('java-1_7_1-ibm-devel')}
   end
 
   context 'select default for SLES 12.1' do


### PR DESCRIPTION
Looks like SLES 11 service pack 4 has updated its canned JRE/JDK again, this just bumps the revision.

I looked for a bit to see whether this could be avoided with a higher-level metapackage for zypper to avoid needing to bump this manually over and over but couldn't find anything - if anyone knows of a flag/package group that could alleviate the need for this, I'm all ears.
