### PR TITLE
(MODULES-2971) Add java_home to all operating systems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,8 +10,10 @@ class java::config ( ) {
         }
       }
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }
@@ -35,36 +37,46 @@ class java::config ( ) {
         }
       }
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }
     'OpenBSD': {
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }
     'FreeBSD': {
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }
     'Suse': {
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }
     'Solaris': {
       if $java::use_java_home != undef {
-        file { '/etc/environment':
-          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        exec { 'java-home-environment':
+          path    => '/bin',
+          user    => 'root',
+          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
         }
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,11 +10,10 @@ class java::config ( ) {
         }
       }
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }
@@ -38,51 +37,46 @@ class java::config ( ) {
         }
       }
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }
     'OpenBSD': {
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }
     'FreeBSD': {
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }
     'Suse': {
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }
     'Solaris': {
       if $java::use_java_home != undef {
-        exec { 'java-home-environment':
-          path    => '/bin',
-          user    => 'root',
-          command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+        file_line { 'java-home-environment':
+          path  => '/etc/environment',
+          line  => "JAVA_HOME=${$java::use_java_home}",
+          match => 'JAVA_HOME=',
         }
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -41,6 +42,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -50,6 +52,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -59,6 +62,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -68,6 +72,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -77,6 +82,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
+          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -42,7 +42,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -52,7 +52,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -62,7 +62,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -72,7 +72,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }
@@ -82,7 +82,7 @@ class java::config ( ) {
           path    => '/bin',
           user    => 'root',
           command => "echo JAVA_HOME=${$java::use_java_home} >> /etc/environment",
-          unless => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
+          unless  => "grep -Fx \"JAVA_HOME=${$java::use_java_home}\" \"/etc/environment\"",
         }
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,11 @@ class java::config ( ) {
           unless  => "test /etc/alternatives/java -ef '${java::use_java_alternative_path}'",
         }
       }
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        }
+      }
     }
     'RedHat': {
       if $java::use_java_alternative != undef and $java::use_java_alternative_path != undef {
@@ -27,6 +32,39 @@ class java::config ( ) {
           path    => '/usr/bin:/usr/sbin',
           command => "alternatives --set java ${$java::use_java_alternative_path}" ,
           unless  => "test /etc/alternatives/java -ef '${java::use_java_alternative_path}'",
+        }
+      }
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        }
+      }
+    }
+    'OpenBSD': {
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        }
+      }
+    }
+    'FreeBSD': {
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        }
+      }
+    }
+    'Suse': {
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
+        }
+      }
+    }
+    'Solaris': {
+      if $java::use_java_home != undef {
+        file { '/etc/environment':
+          content => inline_template("JAVA_HOME=${$java::use_java_home}"),
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@
 #    alternative is actually enabled, this is required to ensure the
 #    correct JVM is enabled.
 #
+#  [*java_home*]
+#   The path to where the JRE is installed. This will be set as an
+#   environment variable.
+#
 # Actions:
 #
 # Requires:
@@ -47,7 +51,8 @@ class java(
   $package               = undef,
   $package_options       = undef,
   $java_alternative      = undef,
-  $java_alternative_path = undef
+  $java_alternative_path = undef,
+  $java_home             = undef
 ) {
   include java::params
 
@@ -61,7 +66,7 @@ class java(
     $default_package_name     = $java::params::java[$distribution]['package']
     $default_alternative      = $java::params::java[$distribution]['alternative']
     $default_alternative_path = $java::params::java[$distribution]['alternative_path']
-    $java_home                = $java::params::java[$distribution]['java_home']
+    $default_java_home        = $java::params::java[$distribution]['java_home']
   } else {
     fail("Java distribution ${distribution} is not supported.")
   }
@@ -89,6 +94,14 @@ class java(
       default               => undef,
     },
     default => $java_alternative_path,
+  }
+
+  $use_java_home = $java_home ? {
+    undef   => $use_java_package_name ? {
+      $default_package_name => $default_java_home,
+      default               => undef,
+    },
+    default => $java_home,
   }
 
   $jre_flag = $use_java_package_name ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,39 +19,52 @@ class java::params {
           if (versioncmp($::operatingsystemrelease, '5.0') < 0) {
             $jdk_package = 'java-1.6.0-sun-devel'
             $jre_package = 'java-1.6.0-sun'
+            $java_home   = '/usr/lib/jvm/java-1.6.0-sun/jre/'
           }
           elsif (versioncmp($::operatingsystemrelease, '6.3') < 0) {
             $jdk_package = 'java-1.6.0-openjdk-devel'
             $jre_package = 'java-1.6.0-openjdk'
+            $java_home   = "/usr/lib/jvm/java-1.6.0-openjdk-${::architecture}/"
           }
           elsif (versioncmp($::operatingsystemrelease, '7.1') < 0) {
             $jdk_package = 'java-1.7.0-openjdk-devel'
             $jre_package = 'java-1.7.0-openjdk'
+            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
           }
           else {
             $jdk_package = 'java-1.8.0-openjdk-devel'
             $jre_package = 'java-1.8.0-openjdk'
+            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/"
           }
         }
         'Fedora': {
           if (versioncmp($::operatingsystemrelease, '21') < 0) {
             $jdk_package = 'java-1.7.0-openjdk-devel'
             $jre_package = 'java-1.7.0-openjdk'
+            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
           }
           else {
             $jdk_package = 'java-1.8.0-openjdk-devel'
             $jre_package = 'java-1.8.0-openjdk'
+            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/"
           }
         }
         'Amazon': {
           $jdk_package = 'java-1.7.0-openjdk-devel'
           $jre_package = 'java-1.7.0-openjdk'
+          $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
         }
         default: { fail("unsupported os ${::operatingsystem}") }
       }
       $java = {
-        'jdk' => { 'package' => $jdk_package, },
-        'jre' => { 'package' => $jre_package, },
+        'jdk' => {
+          'package'   => $jdk_package,
+          'java_home' => $java_home,
+        },
+        'jre' => {
+          'package'   => $jre_package,
+          'java_home' => $java_home,
+        },
       }
     }
     'Debian': {
@@ -145,20 +158,38 @@ class java::params {
     }
     'OpenBSD': {
       $java = {
-        'jdk' => { 'package' => 'jdk', },
-        'jre' => { 'package' => 'jre', },
+        'jdk' => {
+          'package'   => 'jdk',
+          'java_home' => '/usr/local/jdk/',
+        },
+        'jre' => {
+          'package'   => 'jre',
+          'java_home' => '/usr/local/jdk/',
+        },
       }
     }
     'FreeBSD': {
       $java = {
-        'jdk' => { 'package' => 'openjdk', },
-        'jre' => { 'package' => 'openjdk-jre', },
+        'jdk' => {
+          'package'   => 'openjdk',
+          'java_home' => '/usr/local/openjdk7/',
+        },
+        'jre' => {
+          'package'   => 'openjdk-jre',
+          'java_home' => '/usr/local/openjdk7/',
+        },
       }
     }
     'Solaris': {
       $java = {
-        'jdk' => { 'package' => 'developer/java/jdk-7', },
-        'jre' => { 'package' => 'runtime/java/jre-7', },
+        'jdk' => {
+          'package'   => 'developer/java/jdk-7',
+          'java_home' => '/usr/jdk/instances/jdk1.7.0/',
+        },
+        'jre' => {
+          'package'   => 'runtime/java/jre-7',
+          'java_home' => '/usr/jdk/instances/jdk1.7.0/',
+        },
       }
     }
     'Suse': {
@@ -167,26 +198,37 @@ class java::params {
           if (versioncmp($::operatingsystemrelease, '12') >= 0) {
             $jdk_package = 'java-1_7_0-openjdk-devel'
             $jre_package = 'java-1_7_0-openjdk'
+            $java_home   = '/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/'
           } elsif (versioncmp($::operatingsystemrelease, '11.4') >= 0) {
             $jdk_package = 'java-1_7_0-ibm-devel'
             $jre_package = 'java-1_7_0-ibm'
+            $java_home   = '/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/'
           } else {
             $jdk_package = 'java-1_6_0-ibm-devel'
             $jre_package = 'java-1_6_0-ibm'
+            $java_home   = '/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/'
           }
         }
         'OpenSuSE': {
           $jdk_package = 'java-1_7_0-openjdk-devel'
           $jre_package = 'java-1_7_0-openjdk'
+          $java_home   = '/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/'
         }
         default: {
           $jdk_package = 'java-1_6_0-ibm-devel'
           $jre_package = 'java-1_6_0-ibm'
+          $java_home   = '/usr/lib64/jvm/java-1.6.0-ibd-1.6.0/'
         }
       }
       $java = {
-        'jdk' => { 'package' => $jdk_package, },
-        'jre' => { 'package' => $jre_package, },
+        'jdk' => {
+          'package'   => $jdk_package,
+          'java_home' => $java_home,
+        },
+        'jre' => {
+          'package'   => $jre_package,
+          'java_home' => $java_home,
+        },
       }
     }
     default: { fail("unsupported platform ${::osfamily}") }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -3,18 +3,21 @@ require 'spec_helper'
 describe 'java', :type => :class do
 
   context 'select openjdk for Centos 5.8' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.8'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.8', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 7.1.1503' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.2' do
@@ -32,25 +35,29 @@ describe 'java', :type => :class do
   end
 
   context 'select openjdk for Fedora 20' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Fedora 21' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Fedora 20' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20'} }
-    let(:params) { { 'distribution' => 'jre' } }
+    let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/lib/jre/') }
   end
 
   context 'select passed value for Fedora 21' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21'} }
-    let(:params) { { 'distribution' => 'jre' } }
+    let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/lib/jre') }
   end
   
   context 'select passed value for Fedora 21 with yum option' do
@@ -62,7 +69,7 @@ describe 'java', :type => :class do
 
   context 'select passed value for Centos 5.3' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3'} }
-    let(:params) { { 'package' => 'jdk' } }
+    let(:params) { { 'package' => 'jdk', 'java_home' => '/usr/local/lib/jre' } }
     it { is_expected.to contain_package('java').with_name('jdk') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
@@ -77,6 +84,7 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
   end
 
   context 'select Oracle JRE for Debian Wheezy' do
@@ -84,6 +92,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'oracle-jre' } }
     it { is_expected.to contain_package('java').with_name('oracle-j2re1.7') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/j2re1.7-oracle/') }
   end
 
   context 'select OpenJDK JRE for Debian Wheezy' do
@@ -91,6 +100,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
   end
 
   context 'select default for Debian Squeeze' do
@@ -104,6 +114,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { is_expected.to contain_package('java').with_name('sun-java6-jre') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-6-sun/jre/') }
   end
 
   context 'select OpenJDK JRE for Debian Squeeze' do
@@ -111,6 +122,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre', } }
     it { is_expected.to contain_package('java').with_name('openjdk-6-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-6-openjdk/jre/') }
   end
 
   context 'select random alternative for Debian Wheezy' do
@@ -124,17 +136,20 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jdk' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select jre for Ubuntu Vivid (15.04)' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jre-headless') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select openjdk for Amazon Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Amazon Linux' do
@@ -160,34 +175,40 @@ describe 'java', :type => :class do
   end
 
   context 'select passed value for Scientific Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Scientific', :operatingsystemrelease => '6.4'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Scientific', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select default for OpenSUSE 12.3' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3'}}
     it { is_expected.to contain_package('java').with_name('java-1_7_0-openjdk-devel')}
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select default for SLES 11.3' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3'}}
     it { should contain_package('java').with_name('java-1_6_0-ibm-devel')}
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/') }
   end
 
   context 'select default for SLES 11.4' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4'}}
     it { should contain_package('java').with_name('java-1_7_0-ibm-devel')}
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/') }
   end
 
   context 'select default for SLES 12.1' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12'}}
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select jdk for OpenBSD' do
     let(:facts) { {:osfamily => 'OpenBSD'} }
     it { is_expected.to contain_package('java').with_name('jdk') }
+    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/jdk/') }
   end
 
   context 'select jre for OpenBSD' do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -5,19 +5,19 @@ describe 'java', :type => :class do
   context 'select openjdk for Centos 5.8' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.8', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.3' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 7.1.1503' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.2' do
@@ -37,27 +37,27 @@ describe 'java', :type => :class do
   context 'select openjdk for Fedora 20' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Fedora 21' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Fedora 20' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/lib/jre/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/lib/jre/') }
   end
 
   context 'select passed value for Fedora 21' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/lib/jre/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/lib/jre/') }
   end
   
   context 'select passed value for Fedora 21 with yum option' do
@@ -84,7 +84,7 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
   end
 
   context 'select Oracle JRE for Debian Wheezy' do
@@ -92,7 +92,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'oracle-jre' } }
     it { is_expected.to contain_package('java').with_name('oracle-j2re1.7') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/j2re1.7-oracle/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/j2re1.7-oracle/') }
   end
 
   context 'select OpenJDK JRE for Debian Wheezy' do
@@ -100,7 +100,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
   end
 
   context 'select default for Debian Squeeze' do
@@ -114,7 +114,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { is_expected.to contain_package('java').with_name('sun-java6-jre') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-6-sun/jre/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-6-sun/jre/') }
   end
 
   context 'select OpenJDK JRE for Debian Squeeze' do
@@ -122,7 +122,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre', } }
     it { is_expected.to contain_package('java').with_name('openjdk-6-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-6-openjdk/jre/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-6-openjdk/jre/') }
   end
 
   context 'select random alternative for Debian Wheezy' do
@@ -136,20 +136,20 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jdk' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select jre for Ubuntu Vivid (15.04)' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jre-headless') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select openjdk for Amazon Linux' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Amazon Linux' do
@@ -178,37 +178,37 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Scientific', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select default for OpenSUSE 12.3' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3', :architecture => 'x86_64'}}
     it { is_expected.to contain_package('java').with_name('java-1_7_0-openjdk-devel')}
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select default for SLES 11.3' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_6_0-ibm-devel')}
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/') }
   end
 
   context 'select default for SLES 11.4' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_7_0-ibm-devel')}
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/') }
   end
 
   context 'select default for SLES 12.1' do
     let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select jdk for OpenBSD' do
     let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('jdk') }
-    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/jdk/ >> /etc/environment') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/jdk/') }
   end
 
   context 'select jre for OpenBSD' do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -5,29 +5,29 @@ describe 'java', :type => :class do
   context 'select openjdk for Centos 5.8' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.8', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select openjdk for Centos 6.3' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select openjdk for Centos 7.1.1503' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select openjdk for Centos 6.2' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.2'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.2', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
 
   context 'select Oracle JRE with alternatives for Centos 6.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
     let(:params) { { 'package' => 'jre', 'java_alternative' => '/usr/bin/java', 'java_alternative_path' => '/usr/java/jre1.7.0_67/bin/java'} }
     it { is_expected.to contain_package('java').with_name('jre') }
     it { is_expected.to contain_exec('create-java-alternatives').with_command('alternatives --install /usr/bin/java java /usr/java/jre1.7.0_67/bin/java 20000') }
@@ -37,45 +37,45 @@ describe 'java', :type => :class do
   context 'select openjdk for Fedora 20' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select openjdk for Fedora 21' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select passed value for Fedora 20' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/lib/jre/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/lib/jre/ >> /etc/environment') }
   end
 
   context 'select passed value for Fedora 21' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21'} }
-    let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre' } }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
+    let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/lib/jre') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/lib/jre/ >> /etc/environment') }
   end
   
   context 'select passed value for Fedora 21 with yum option' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     let(:params) { { 'package_options'  => ['--skip-broken'] } }
     it { is_expected.to contain_package('java') }
   end
 
   context 'select passed value for Centos 5.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3', :architecture => 'x86_64'} }
     let(:params) { { 'package' => 'jdk', 'java_home' => '/usr/local/lib/jre' } }
     it { is_expected.to contain_package('java').with_name('jdk') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
 
   context 'select default for Centos 5.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
@@ -84,7 +84,7 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/ >> /etc/environment') }
   end
 
   context 'select Oracle JRE for Debian Wheezy' do
@@ -92,7 +92,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'oracle-jre' } }
     it { is_expected.to contain_package('java').with_name('oracle-j2re1.7') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/j2re1.7-oracle/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/j2re1.7-oracle/ >> /etc/environment') }
   end
 
   context 'select OpenJDK JRE for Debian Wheezy' do
@@ -100,7 +100,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/ >> /etc/environment') }
   end
 
   context 'select default for Debian Squeeze' do
@@ -114,7 +114,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { is_expected.to contain_package('java').with_name('sun-java6-jre') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-6-sun/jre/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-6-sun/jre/ >> /etc/environment') }
   end
 
   context 'select OpenJDK JRE for Debian Squeeze' do
@@ -122,7 +122,7 @@ describe 'java', :type => :class do
     let(:params) { { 'distribution' => 'jre', } }
     it { is_expected.to contain_package('java').with_name('openjdk-6-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-6-openjdk/jre/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-6-openjdk/jre/ >> /etc/environment') }
   end
 
   context 'select random alternative for Debian Wheezy' do
@@ -136,40 +136,40 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jdk' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/ >> /etc/environment') }
   end
 
   context 'select jre for Ubuntu Vivid (15.04)' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jre-headless') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/ >> /etc/environment') }
   end
 
   context 'select openjdk for Amazon Linux' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select passed value for Amazon Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '5.3.4.43-43.43.amzn1.x86_64'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '5.3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
   end
 
   context 'select openjdk for Oracle Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.4'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
   end
 
   context 'select openjdk for Oracle Linux 6.2' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.2'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.2', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
   end
 
   context 'select passed value for Oracle Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.3'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
   end
@@ -178,41 +178,41 @@ describe 'java', :type => :class do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Scientific', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/ >> /etc/environment') }
   end
 
   context 'select default for OpenSUSE 12.3' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3'}}
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3', :architecture => 'x86_64'}}
     it { is_expected.to contain_package('java').with_name('java-1_7_0-openjdk-devel')}
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/ >> /etc/environment') }
   end
 
   context 'select default for SLES 11.3' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3'}}
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_6_0-ibm-devel')}
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/ >> /etc/environment') }
   end
 
   context 'select default for SLES 11.4' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4'}}
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_7_0-ibm-devel')}
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/ >> /etc/environment') }
   end
 
   context 'select default for SLES 12.1' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12'}}
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/ >> /etc/environment') }
   end
 
   context 'select jdk for OpenBSD' do
-    let(:facts) { {:osfamily => 'OpenBSD'} }
+    let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('jdk') }
-    it { is_expected.to contain_file('/etc/environment').with_content('JAVA_HOME=/usr/local/jdk/') }
+    it { is_expected.to contain_exec('java-home-environment').with_command('echo JAVA_HOME=/usr/local/jdk/ >> /etc/environment') }
   end
 
   context 'select jre for OpenBSD' do
-    let(:facts) { {:osfamily => 'OpenBSD'} }
+    let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('jre') }
   end


### PR DESCRIPTION
This patch adds the java_home variable to all supported
operating systemd, and gives the user the option to
set it themselves. It also updates config.pp to
ensure that the JAVA_HOME variable is set to
the desired java_home.