### PR TITLE
Support recent java versions > 8u99 built with make-jpkg 0.53

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,10 @@ class java::params {
       }
     }
     'Debian': {
+      $oracle_architecture = $::architecture ? {
+        'amd64' => 'x64',
+        default => $::architecture
+      }
       case $::lsbdistcodename {
         'lenny', 'squeeze', 'lucid', 'natty': {
           $java  = {
@@ -84,7 +88,7 @@ class java::params {
             },
           }
         }
-        'wheezy', 'jessie', 'precise','quantal','raring','saucy', 'trusty', 'utopic': {
+        'wheezy', 'jessie', 'precise', 'quantal', 'raring', 'saucy', 'trusty', 'utopic': {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-7-jdk',
@@ -121,7 +125,19 @@ class java::params {
               'alternative'      => 'j2sdk1.8-oracle',
               'alternative_path' => '/usr/lib/jvm/j2sdk1.8-oracle/bin/java',
               'java_home'        => '/usr/lib/jvm/j2sdk1.8-oracle/',
-              },
+            },
+            'oracle-java8-jre' => {
+              'package'          => 'oracle-java8-jre',
+              'alternative'      => "jre-8-oracle-${oracle_architecture}",
+              'alternative_path' => "/usr/lib/jvm/jre-8-oracle-${oracle_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/jre-8-oracle-${oracle_architecture}/",
+            },
+            'oracle-java8-jdk' => {
+              'package'          => 'oracle-java8-jdk',
+              'alternative'      => "jdk-8-oracle-${oracle_architecture}",
+              'alternative_path' => "/usr/lib/jvm/jdk-8-oracle-${oracle_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/jdk-8-oracle-${oracle_architecture}/",
+            },
           }
         }
         'vivid', 'wily', 'xenial': {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -86,6 +86,21 @@ describe 'java', :type => :class do
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
   end
 
+  context 'select Oracle Java 8 JRE >=u100 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-java8-jre' } }
+    it { is_expected.to contain_package('java').with_name('oracle-java8-jre') }
+    it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jre-8-oracle-x64 --jre') }
+  end
+
+  context 'select Oracle Java 8 JDK >=u100 for Debian Wheezy' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:params) { { 'distribution' => 'oracle-java8-jdk' } }
+    it { is_expected.to contain_package('java').with_name('oracle-java8-jdk') }
+    it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jdk-8-oracle-x64 --jre') }
+  end
+
+
   context 'select OpenJDK JRE for Debian Wheezy' do
     let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
     let(:params) { { 'distribution' => 'jre' } }


### PR DESCRIPTION
The previous make-jpkg from java-package_0.50 doesn't support building java
versions with three digits in the release number.  Therefore it has been
necessary to upgrade java-packaages to the newer 0.53 version.

Building oracle packages using the java-package tools 0.53 results in package
with a new naming scheme as compared to 0.50.  In particular where the packages
were previously named oracle-j2re1.8 they are now named oracle-java8-jre, while
oracle-j2dk1.8 has become oracle-java8-jdk.  The alternatives naming has also
changed.

We also need to handle the system architecture naming on debian systems where
Debian names it's 64bit architecture 'amd64' and Oracle use 'x64'.  This results
in the java_home path using x64 rather than amd64.  We need to handle this
variation while also accommodating all architectures, and only for the recent
packages.

Given this has only been tested on Ubuntu, and the make-jpkg tooling is managed
in the Debian flavour, the changes are only applied to that code branch.

Jinn Koriech & Doug Neal