### PR TITLE
(maint) ci fix for install_spec

### DIFF
--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -136,14 +136,17 @@ end
 
 describe 'failure cases' do
   # C14711
-  it 'should fail to install java with an incorrect version' do
-    pp = <<-EOS
+  # SLES 10 returns an exit code of 0 on zypper failure
+  unless fact('operatingsystem') == 'SLES' and fact('operatingsystemrelease') < '11'
+    it 'should fail to install java with an incorrect version' do
+      pp = <<-EOS
       class { 'java':
         version => '14.5',
       }
     EOS
 
     apply_manifest(pp, :expect_failures => true)
+    end
   end
 
   # C14712


### PR DESCRIPTION
Zypper on SLES 10.4 exits with 0 when it cannot find the "wrong" java package specified in the test, so the test doesn't know that it didn't work. To work around this, I removed this test for SLES < 11. 