### PR TITLE
Unbreak on OpenBSD

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,10 +46,17 @@ class java::config ( ) {
     }
     'OpenBSD': {
       if $java::use_java_home != undef {
+        file { '/etc/environment':
+          ensure => 'file',
+          owner  => 'root',
+          group  => '0',
+          mode   => '0644',
+        }
         file_line { 'java-home-environment':
-          path  => '/etc/environment',
-          line  => "JAVA_HOME=${$java::use_java_home}",
-          match => 'JAVA_HOME=',
+          path    => '/etc/environment',
+          line    => "JAVA_HOME=${$java::use_java_home}",
+          match   => 'JAVA_HOME=',
+          require => File['/etc/environment'],
         }
       }
     }


### PR DESCRIPTION
Create /etc/environment file before trying to manipulate it
On OpenBSD such a file doesn't exist

The change that introduced that fiddling with the /etc/environment file broke the module on OpenBSD,
since the file doesn't exist in the first place, and file_line then errors out.
As a quick fix, just ensure the file exists, before trying to edit it.
