### PR TITLE
#MODULES-4069: Fail when required params are not available in params.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,15 +53,11 @@ class java(
   Optional[String] $java_alternative_path                           = undef,
   Optional[String] $java_home                                       = undef
 ) {
-  include java::params
+  include ::java::params
 
-  if has_key($java::params::java, $distribution) {
-    $default_package_name     = $java::params::java[$distribution]['package']
-    $default_alternative      = $java::params::java[$distribution]['alternative']
-    $default_alternative_path = $java::params::java[$distribution]['alternative_path']
-    $default_java_home        = $java::params::java[$distribution]['java_home']
-  } else {
-    fail("Java distribution ${distribution} is not supported.")
+  $default_package_name = has_key($java::params::java, $distribution) ? {
+    false   => undef,
+    default => $java::params::java[$distribution]['package'],
   }
 
   $use_java_package_name = $package ? {
@@ -69,12 +65,17 @@ class java(
     default => $package,
   }
 
+
+  ## Weird logic........
   ## If $java_alternative is set, use that.
   ## Elsif the DEFAULT package is being used, then use $default_alternative.
   ## Else undef
   $use_java_alternative = $java_alternative ? {
-    undef   => $use_java_package_name ? {
-      $default_package_name => $default_alternative,
+    undef                   => $use_java_package_name ? {
+      $default_package_name => has_key($java::params::java, $distribution) ? {
+        default => $java::params::java[$distribution]['alternative'],
+        false => undef,
+      },
       default               => undef,
     },
     default => $java_alternative,
@@ -82,19 +83,36 @@ class java(
 
   ## Same logic as $java_alternative above.
   $use_java_alternative_path = $java_alternative_path ? {
-    undef   => $use_java_package_name ? {
-      $default_package_name => $default_alternative_path,
+    undef                   => $use_java_package_name ? {
+      $default_package_name => has_key($java::params::java, $distribution) ? {
+      default               => $java::params::java[$distribution]['alternative_path'],
+      false                 => undef,
+      },
       default               => undef,
     },
     default => $java_alternative_path,
   }
 
   $use_java_home = $java_home ? {
-    undef   => $use_java_package_name ? {
-      $default_package_name => $default_java_home,
+    undef                   => $use_java_package_name ? {
+      $default_package_name => has_key($java::params::java, $distribution) ? {
+        default             => $java::params::java[$distribution]['java_home'],
+        false               => undef,
+      },
       default               => undef,
     },
     default => $java_home,
+  }
+
+  ## This should only be required if we did not override all the information we need.
+  # One of the defaults is missing and its not intentional:
+  if ((
+      $use_java_package_name == undef or $use_java_alternative == undef or
+      $use_java_alternative_path == undef or $use_java_home == undef
+    ) and (
+      ! has_key($::java::params::java, $distribution)
+    )) {
+    fail("Java distribution ${distribution} is not supported. Missing default values.")
   }
 
   $jre_flag = $use_java_package_name ? {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -245,6 +245,34 @@ describe 'java', :type => :class do
     it { is_expected.to contain_package('java').with_name('jre') }
   end
 
+  describe 'custom java package' do
+    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'jessie', :operatingsystemrelease => '8.6', :architecture => 'amd64',} }
+    context 'all params provided' do
+      let(:params) { {
+        'distribution'          => 'custom',
+        'package'               => 'custom_jdk',
+        'java_alternative'      => 'java-custom_jdk',
+        'java_alternative_path' => '/opt/custom_jdk/bin/java',
+        'java_home'             => '/opt/custom_jdk',
+      } }
+
+      it { is_expected.to contain_package('java').with_name('custom_jdk') }
+      it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/opt/custom_jdk') }
+      it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-custom_jdk --jre') }
+
+    end
+    context 'missing parameters' do
+      let(:params) { {
+        'distribution' => 'custom',
+        'package' => 'custom_jdk',
+      } }
+      it do
+        expect { catalogue }.to raise_error Puppet::Error, /is not supported. Missing default values/
+      end
+    end
+  end
+
+
   describe 'incompatible OSs' do
     [
       {


### PR DESCRIPTION
When overriding all values required for the java setup, there is
no need to fail if params.pp does not support the package.