### PR TITLE
add 'Amazon Linux AMI' supports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,33 +32,34 @@ supports_windows = false
 
 group :development do
   gem 'puppet-lint',                        :require => false
-  gem 'metadata-json-lint',                 :require => false
+  gem 'metadata-json-lint',                 :require => false, :platforms => 'ruby'
   gem 'puppet_facts',                       :require => false
   gem 'puppet-blacksmith', '>= 3.4.0',      :require => false, :platforms => 'ruby'
   gem 'puppetlabs_spec_helper', '>= 1.2.1', :require => false
   gem 'rspec-puppet', '>= 2.3.2',           :require => false
-  gem 'rspec-puppet-facts',                 :require => false
+  gem 'rspec-puppet-facts',                 :require => false, :platforms => 'ruby'
   gem 'mocha', '< 1.2.0',                   :require => false
-  gem 'simplecov',                          :require => false
-  gem 'parallel_tests', '< 2.10.0',         :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  gem 'parallel_tests',                     :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-  gem 'rubocop', '0.41.2',                  :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  gem 'rubocop',                            :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
-  gem 'rubocop-rspec', '~> 1.6',            :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+  gem 'simplecov',                          :require => false, :platforms => 'ruby'
+  gem 'parallel_tests', '< 2.10.0',         :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem 'parallel_tests',                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+  gem 'rubocop', '0.41.2',                  :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem 'rubocop',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+  gem 'rubocop-rspec', '~> 1.6',            :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
   gem 'pry',                                :require => false
-  gem 'json_pure', '<= 2.0.1',              :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+  gem 'json_pure', '<= 2.0.1',              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
 end
 
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')                if supports_windows
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'])                             if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0') and ! supports_windows
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '< 3')                    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0') and ! supports_windows
-  gem 'beaker-pe',                                                               :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'])                             if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0') and ! supports_windows
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '< 3')                    if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0') and ! supports_windows
+  gem 'beaker-pe',                                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')     if ! supports_windows
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')     if supports_windows
   gem 'beaker-puppet_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
+  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -145,7 +145,7 @@ define java::oracle (
   case $::kernel {
     'Linux' : {
       case $::osfamily {
-        'RedHat' : {
+        'RedHat', 'Amazon' : {
           # Oracle Java 6 comes in a special rpmbin format
           if $version == '6' {
             $package_type = 'rpmbin'


### PR DESCRIPTION
[Amazon Linux AMI](https://aws.amazon.com/cn/amazon-linux-ami/2016.09-release-notes/) is another RedHat-like os image, openjdk-7 was shipped in that image but we  want more choices or jdk 8. i'd been tested ok for oracle jdk installation on a 't2.micro' instance.