### PR TITLE
Ubuntu update

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -153,6 +153,11 @@ define java::oracle (
             $package_type = 'rpm'
           }
         }
+
+        'Debian': {
+            $package_type = 'tgz'
+        }
+
         default : {
           fail ("unsupported platform ${::operatingsystem}") }
       }
@@ -168,7 +173,7 @@ define java::oracle (
   # set java architecture nomenclature
   case $::architecture {
     'i386' : { $arch = 'i586' }
-    'x86_64' : { $arch = 'x64' }
+    'amd64', 'x86_64' : { $arch = 'x64' }
     default : {
       fail ("unsupported platform ${::architecture}")
     }

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -191,6 +191,9 @@ define java::oracle (
     'rpm' : {
       $package_name = "${java_se}-${release_major}-${os}-${arch}.rpm"
     }
+    'tgz' : {
+      $package_name = "${java_se}-${release_major}-${os}-${arch}.tar.gz"
+    }
     default : {
       $package_name = "${java_se}-${release_major}-${os}-${arch}.rpm"
     }
@@ -210,6 +213,10 @@ define java::oracle (
     'rpm' : {
       $install_command = "rpm --force -iv ${destination}"
     }
+    'tgz': {
+      $install_command = "mv ${install_path} /usr/java/"
+    }
+
     default : {
       $install_command = "rpm -iv ${destination}"
     }
@@ -217,20 +224,31 @@ define java::oracle (
 
   case $ensure {
     'present' : {
+      if $package_type == 'tgz' {
+        $extract = true
+      }
+
+      else {
+        $extract = false
+      }
+
       archive { $destination :
         ensure       => present,
         source       => "${oracle_url}${release_major}-${release_minor}/${package_name}",
         cookie       => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+        extract      => $extract,
         extract_path => '/tmp',
         cleanup      => false,
         creates      => $creates_path,
         proxy_server => $proxy_server,
         proxy_type   => $proxy_type,
       }->
+
       case $::kernel {
         'Linux' : {
           exec { "Install Oracle java_se ${java_se} ${version}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+            cwd     => '/tmp',
             command => $install_command,
             creates => $creates_path,
           }

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper_acceptance'
 #RedHat, CentOS, Scientific, Oracle after 6.3     : OpenJDK Java JDK/JRE 1.7
 #Debian 5/6 & Ubuntu 10.04/11.04                  : OpenJDK Java JDK/JRE 1.6 or Sun Java JDK/JRE 1.6
 #Debian 7/Jesse & Ubuntu 12.04 - 14.04            : OpenJDK Java JDK/JRE 1.7 or Oracle Java JDK/JRE 1.6
+#Debian 8 & Ubuntu 16.04                          : OpenJDK Java JDK/JRE 1.8 or Oracle Java JDK/JRE 1.8
 #Solaris (what versions?)                         : Java JDK/JRE 1.7
 #OpenSuSE                                         : OpenJDK Java JDK/JRE 1.7
 #SLES                                             : IBM Java JDK/JRE 1.6
@@ -104,7 +105,8 @@ end
 describe 'oracle', :if => (
   (fact('operatingsystem') == 'Debian') and (fact('operatingsystemrelease').match(/^7/)) or
   (fact('operatingsystem') == 'Ubuntu') and (fact('operatingsystemrelease').match(/^12\.04/)) or
-  (fact('operatingsystem') == 'Ubuntu') and (fact('operatingsystemrelease').match(/^14\.04/))
+  (fact('operatingsystem') == 'Ubuntu') and (fact('operatingsystemrelease').match(/^14\.04/)) or
+  (fact('operatingsystem') == 'Ubuntu') and (fact('operatingsystemrelease').match(/^16\.04/))
 ) do
   # not supported
   # The package is not available from any sources, but if a customer


### PR DESCRIPTION
Debian and Ubuntu servers must use the tar.gz packages for the java jdk, there are no official deb files available.