### PR TITLE
[MODULES-4736] Increase Xmx setting for java_version fact

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -23,7 +23,7 @@ Facter.add(:java_version) do
   setcode do
     unless [ 'openbsd', 'darwin' ].include? Facter.value(:operatingsystem).downcase
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
       end
     end
   end
@@ -35,7 +35,7 @@ Facter.add(:java_version) do
   setcode do
     Facter::Util::Resolution.with_env("PATH" => '/usr/local/jdk-1.7.0/jre/bin:/usr/local/jre-1.7.0/bin') do
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
       end
     end
   end
@@ -46,7 +46,7 @@ Facter.add(:java_version) do
   has_weight 100
   setcode do
     unless /Unable to find any JVMs matching version/ =~ Facter::Util::Resolution.exec('/usr/libexec/java_home --failfast 2>&1')
-      Facter::Util::Resolution.exec('java -Xmx8m -version 2>&1').lines.first.split(/"/)[1].strip
+      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
     end
   end
 end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -19,7 +19,7 @@ OpenJDK Runtime Environment (build 1.7.0_71-b14)
 OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
           EOS
           Facter::Util::Resolution.expects(:which).with("java").returns('/usr/local/jdk-1.7.0/jre/bin/java')
-          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx12m -version 2>&1").returns(java_version_output)
           expect(Facter.value(:java_version)).to eq("1.7.0_71")
         end
       end
@@ -35,7 +35,7 @@ Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
           EOS
           Facter::Util::Resolution.expects(:exec).with("/usr/libexec/java_home --failfast 2>&1").returns("/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home")
-          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx12m -version 2>&1").returns(java_version_output)
           expect(Facter.value(:java_version)).to eql "1.7.0_71"
         end
       end
@@ -50,7 +50,7 @@ java version "1.7.0_71"
 Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
           EOS
-          Facter::Util::Resolution.expects(:exec).with("java -Xmx8m -version 2>&1").returns(java_version_output)
+          Facter::Util::Resolution.expects(:exec).with("java -Xmx12m -version 2>&1").returns(java_version_output)
           expect(Facter.value(:java_version)).to eq("1.7.0_71")
         end
       end


### PR DESCRIPTION
Previous value of 8M caused JVM to crash on servers with more then 40G of RAM
Tested on databases servers up to 1.5T of RAM, 12M seems to be sufficient