### PR TITLE
Update OpenJDK packages to 1.8.0 for SLES 12 service packs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -170,7 +170,7 @@ OpenJDK is supported on:
 * Debian 6, 7
 * Ubuntu 10.04, 12.04, 14.04
 * Solaris 11
-* SLES 11 SP1, 12 
+* SLES 11 SP1, SP2, SP3, SP4; SLES 12, SP1, SP2
 * OpenBSD 5.6, 5.7
 
 Sun Java is supported on:  

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -211,7 +211,11 @@ class java::params {
     'Suse': {
       case $::operatingsystem {
         'SLES': {
-          if (versioncmp($::operatingsystemrelease, '12') >= 0) {
+          if (versioncmp($::operatingsystemrelease, '12.1') >= 0) {
+            $jdk_package = 'java-1_8_0-openjdk-devel'
+            $jre_package = 'java-1_8_0-openjdk'
+            $java_home   = '/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/'
+          } elsif (versioncmp($::operatingsystemrelease, '12') >= 0) {
             $jdk_package = 'java-1_7_0-openjdk-devel'
             $jre_package = 'java-1_7_0-openjdk'
             $java_home   = '/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/'

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,12 @@
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "11 SP1",
-        "12"
+        "11 SP2",
+        "11 SP3",
+        "11 SP4",
+        "12",
+        "12 SP1",
+        "12 SP2"
       ]
     },
     {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -221,10 +221,16 @@ describe 'java', :type => :class do
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/') }
   end
 
-  context 'select default for SLES 12.1' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
+  context 'select default for SLES 12.0' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.0', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
+  end
+
+  context 'select default for SLES 12.1' do
+    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
+    it { should contain_package('java').with_name('java-1_8_0-openjdk-devel')}
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/') }
   end
 
   context 'select jdk for OpenBSD' do


### PR DESCRIPTION
SLES 12.1 and SLES 12.2 have OpenJDK 1.8.0 available to them, as per the [release notes](https://www.suse.com/releasenotes/x86_64/SUSE-SLED/12-SP1/#fate-318956) for SP1. This change allows machines with these service packs to install 1.8.0 by default instead of 1.7.0.