### PR TITLE
(maint) update metadata, remove archive fixture pin, and update facts

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,6 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive:
-      repo: "git://github.com/voxpupuli/puppet-archive.git"
+    archive: "git://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     java: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,5 @@ fixtures:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     archive:
       repo: "git://github.com/voxpupuli/puppet-archive.git"
-      ref: "v1.2.0"
   symlinks:
     java: "#{source_dir}"

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -142,9 +142,9 @@ define java::oracle (
   }
 
   # determine package type (exe/tar/rpm), destination directory based on OS
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux' : {
-      case $::osfamily {
+      case $facts['os']['family'] {
         'RedHat', 'Amazon' : {
           # Oracle Java 6 comes in a special rpmbin format
           if $version == '6' {
@@ -154,7 +154,7 @@ define java::oracle (
           }
         }
         default : {
-          fail ("unsupported platform ${::operatingsystem}") }
+          fail ("unsupported platform ${$facts['os']['name']}") }
       }
 
       $os = 'linux'
@@ -162,15 +162,15 @@ define java::oracle (
       $creates_path = "/usr/java/${install_path}"
     }
     default : {
-      fail ( "unsupported platform ${::kernel}" ) }
+      fail ( "unsupported platform ${$facts['kernel']}" ) }
   }
 
   # set java architecture nomenclature
-  case $::architecture {
+  case $facts['os']['architecture'] {
     'i386' : { $arch = 'i586' }
     'x86_64' : { $arch = 'x64' }
     default : {
-      fail ("unsupported platform ${::architecture}")
+      fail ("unsupported platform ${$facts['os']['architecture']}")
     }
   }
 
@@ -227,7 +227,7 @@ define java::oracle (
         proxy_server => $proxy_server,
         proxy_type   => $proxy_type,
       }
-      case $::kernel {
+      case $facts['kernel'] {
         'Linux' : {
           exec { "Install Oracle java_se ${java_se} ${version}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
@@ -237,7 +237,7 @@ define java::oracle (
           }
         }
         default : {
-          fail ("unsupported platform ${::kernel}")
+          fail ("unsupported platform ${$facts['kernel']}")
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-java",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "author": "puppetlabs",
   "summary": "Installs the correct Java package on various platforms.",
   "license": "Apache-2.0",
@@ -90,6 +90,6 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"},
-    {"name":"puppet/archive","version_requirement":">= 1.1.0 < 1.2.0"}
+    {"name":"puppet/archive","version_requirement":">= 1.1.0 < 2.0.0"}
   ]
 }

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'java::oracle', :type => :define do
     context 'On CentOS 64-bit' do
-      let(:facts) { {:kernel => 'Linux', :architecture => 'x86_64', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+      let(:facts) { { :kernel => 'Linux', :os => {:family => 'RedHat', :architecture => 'x86_64', :name => 'CentOS', :release => {:full => '6.0'}}}}
 
       context 'Oracle Java SE 6 JDK' do
       let(:params) { {:ensure => 'present', :version => '6', :java_se => 'jdk'} }
@@ -55,7 +55,7 @@ describe 'java::oracle', :type => :define do
   end
 
   context 'On CentOS 32-bit' do
-    let(:facts) { {:kernel => 'Linux', :architecture => 'i386', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+    let(:facts) { {:kernel => 'Linux',  :os => { :family => 'RedHat', :architecture => 'i386', :name => 'CentOS', :release => { :full => '6.6' } } } }
 
     context 'select Oracle Java SE 6 JDK on RedHat family, 32-bit' do
       let(:params) { {:ensure => 'present', :version => '6', :java_se => 'jdk'} }
@@ -106,52 +106,67 @@ describe 'java::oracle', :type => :define do
     end
   end
 
-  describe 'incompatible OSs' do
+  describe 'incompatible OSes' do
     [
       {
         # C14706
-        :kernel                 => 'windows',
-        :osfamily               => 'windows',
-        :operatingsystem        => 'windows',
-        :operatingsystemrelease => '8.1',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'Windows',
+        :os => {
+          :family => 'Windows',
+          :name => 'Windows',
+          :release => {
+            :full => '8.1'
+          }
+        },
       },
       {
         # C14707
-        :kernel                 => 'Darwin',
-        :osfamily               => 'Darwin',
-        :operatingsystem        => 'Darwin',
-        :operatingsystemrelease => '13.3.0',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'Darwin',
+        :os => {
+          :family => 'Darwin',
+          :name => 'Darwin',
+          :release => {
+            :full => '13.3.0'
+          }
+        },
       },
       {
         # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '7100-02-00-000',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '7100-02-00-000'
+          }
+        },
       },
       {
-        # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '6100-07-04-1216',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        # C14709
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '6100-07-04-1216'
+          }
+        },
       },
       {
-        # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '5300-12-01-1016',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
-      },
+        # C14710
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '5300-12-01-1016'
+          }
+        },
+      }
     ].each do |facts|
       let(:facts) { facts }
       let :title do 'jdk' end
-      it "is_expected.to fail on #{facts[:operatingsystem]} #{facts[:operatingsystemrelease]}" do
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
         expect { catalogue }.to raise_error Puppet::Error, /unsupported platform/
       end
     end


### PR DESCRIPTION
forgot to update version in metadata for major version bump

puppet-archive, a puppetlabs-java dependency, is now using structured
facts on master. this commit changes the minimum number of facts from
legacy to structured so that spec tests continue to pass