### PR TITLE
(maint) remove legacy facts

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive:
-      repo: "git://github.com/voxpupuli/puppet-archive.git"
-      ref: "v1.2.0"
+    archive: "git://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     java: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # On Debian systems, if alternatives are set, manually assign them.
 class java::config ( ) {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
       if $java::use_java_alternative != undef and $java::use_java_alternative_path != undef {
         exec { 'update-java-alternatives':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,7 +109,7 @@ class java(
     default    => '--jre'
   }
 
-  if $::osfamily == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     # Needed for update-java-alternatives
     package { 'java-common':
       ensure => present,

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -141,10 +141,12 @@ define java::oracle (
     }
   }
 
+  $foo = inline_template("<% require 'pry'; binding.pry %>")
+
   # determine package type (exe/tar/rpm), destination directory based on OS
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux' : {
-      case $::osfamily {
+      case $facts['os']['family'] {
         'RedHat', 'Amazon' : {
           # Oracle Java 6 comes in a special rpmbin format
           if $version == '6' {
@@ -154,7 +156,7 @@ define java::oracle (
           }
         }
         default : {
-          fail ("unsupported platform ${::operatingsystem}") }
+          fail ("unsupported platform ${$facts['os']['name']}") }
       }
 
       $os = 'linux'
@@ -162,15 +164,15 @@ define java::oracle (
       $creates_path = "/usr/java/${install_path}"
     }
     default : {
-      fail ( "unsupported platform ${::kernel}" ) }
+      fail ( "unsupported platform ${$facts['kernel']}" ) }
   }
 
   # set java architecture nomenclature
-  case $::architecture {
+  case $facts['os']['architecture'] {
     'i386' : { $arch = 'i586' }
     'x86_64' : { $arch = 'x64' }
     default : {
-      fail ("unsupported platform ${::architecture}")
+      fail ("unsupported platform ${$facts['os']['architecture']}")
     }
   }
 
@@ -227,7 +229,7 @@ define java::oracle (
         proxy_server => $proxy_server,
         proxy_type   => $proxy_type,
       }
-      case $::kernel {
+      case $facts['kernel'] {
         'Linux' : {
           exec { "Install Oracle java_se ${java_se} ${version}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
@@ -237,7 +239,7 @@ define java::oracle (
           }
         }
         default : {
-          fail ("unsupported platform ${::kernel}")
+          fail ("unsupported platform ${$facts['kernel']}")
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,49 +12,49 @@
 # for the config class to test if it is enabled.
 class java::params {
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'RedHat', 'CentOS', 'OracleLinux', 'Scientific', 'OEL', 'SLC': {
-          if (versioncmp($::operatingsystemrelease, '5.0') < 0) {
+          if (versioncmp($facts['os']['release']['full'], '5.0') < 0) {
             $jdk_package = 'java-1.6.0-sun-devel'
             $jre_package = 'java-1.6.0-sun'
             $java_home   = '/usr/lib/jvm/java-1.6.0-sun/jre/'
           }
-          elsif (versioncmp($::operatingsystemrelease, '6.3') < 0) {
+          elsif (versioncmp($facts['os']['release']['full'], '6.3') < 0) {
             $jdk_package = 'java-1.6.0-openjdk-devel'
             $jre_package = 'java-1.6.0-openjdk'
-            $java_home   = "/usr/lib/jvm/java-1.6.0-openjdk-${::architecture}/"
+            $java_home   = "/usr/lib/jvm/java-1.6.0-openjdk-${$facts['os']['architecture']}/"
           }
-          elsif (versioncmp($::operatingsystemrelease, '7.1') < 0) {
+          elsif (versioncmp($facts['os']['release']['full'], '7.1') < 0) {
             $jdk_package = 'java-1.7.0-openjdk-devel'
             $jre_package = 'java-1.7.0-openjdk'
-            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
+            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/"
           }
           else {
             $jdk_package = 'java-1.8.0-openjdk-devel'
             $jre_package = 'java-1.8.0-openjdk'
-            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/"
+            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/"
           }
         }
         'Fedora': {
-          if (versioncmp($::operatingsystemrelease, '21') < 0) {
+          if (versioncmp($facts['os']['release']['full'], '21') < 0) {
             $jdk_package = 'java-1.7.0-openjdk-devel'
             $jre_package = 'java-1.7.0-openjdk'
-            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
+            $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/"
           }
           else {
             $jdk_package = 'java-1.8.0-openjdk-devel'
             $jre_package = 'java-1.8.0-openjdk'
-            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/"
+            $java_home   = "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/"
           }
         }
         'Amazon': {
           $jdk_package = 'java-1.7.0-openjdk-devel'
           $jre_package = 'java-1.7.0-openjdk'
-          $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/"
+          $java_home   = "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/"
         }
-        default: { fail("unsupported os ${::operatingsystem}") }
+        default: { fail("unsupported os ${$facts['os']['name']}") }
       }
       $java = {
         'jdk' => {
@@ -68,22 +68,22 @@ class java::params {
       }
     }
     'Debian': {
-      $oracle_architecture = $::architecture ? {
+      $oracle_architecture = $facts['os']['architecture'] ? {
         'amd64' => 'x64',
-        default => $::architecture
+        default => $facts['os']['architecture']
       }
-      case $::lsbdistcodename {
+      case $facts['os']['distro']['codename'] {
         'lenny', 'squeeze', 'lucid', 'natty': {
           $java  = {
             'jdk' => {
               'package'          => 'openjdk-6-jdk',
-              'alternative'      => "java-6-openjdk-${::architecture}",
+              'alternative'      => "java-6-openjdk-${$facts['os']['architecture']}",
               'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
               'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
             },
             'jre' => {
               'package'          => 'openjdk-6-jre-headless',
-              'alternative'      => "java-6-openjdk-${::architecture}",
+              'alternative'      => "java-6-openjdk-${$facts['os']['architecture']}",
               'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
               'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
             },
@@ -105,15 +105,15 @@ class java::params {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-7-jdk',
-              'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.7.0-openjdk-${$facts['os']['architecture']}",
+              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/",
             },
             'jre' => {
               'package'          => 'openjdk-7-jre-headless',
-              'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.7.0-openjdk-${$facts['os']['architecture']}",
+              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${$facts['os']['architecture']}/",
             },
             'oracle-jre' => {
               'package'          => 'oracle-j2re1.7',
@@ -157,19 +157,19 @@ class java::params {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-8-jdk',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.8.0-openjdk-${$facts['os']['architecture']}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/",
             },
             'jre' => {
               'package'          => 'openjdk-8-jre-headless',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.8.0-openjdk-${$facts['os']['architecture']}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${$facts['os']['architecture']}/",
             }
           }
         }
-        default: { fail("unsupported release ${::lsbdistcodename}") }
+        default: { fail("unsupported release ${$facts['distro']['codename']}") }
       }
     }
     'OpenBSD': {
@@ -209,17 +209,17 @@ class java::params {
       }
     }
     'Suse': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'SLES': {
-          if (versioncmp($::operatingsystemrelease, '12.1') >= 0) {
+          if (versioncmp($facts['os']['release']['full'], '12.1') >= 0) {
             $jdk_package = 'java-1_8_0-openjdk-devel'
             $jre_package = 'java-1_8_0-openjdk'
             $java_home   = '/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/'
-          } elsif (versioncmp($::operatingsystemrelease, '12') >= 0) {
+          } elsif (versioncmp($facts['os']['release']['full'], '12') >= 0) {
             $jdk_package = 'java-1_7_0-openjdk-devel'
             $jre_package = 'java-1_7_0-openjdk'
             $java_home   = '/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/'
-          } elsif (versioncmp($::operatingsystemrelease, '11.4') >= 0) {
+          } elsif (versioncmp($facts['os']['release']['full'], '11.4') >= 0) {
             $jdk_package = 'java-1_7_1-ibm-devel'
             $jre_package = 'java-1_7_1-ibm'
             $java_home   = '/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/'
@@ -251,6 +251,6 @@ class java::params {
         },
       }
     }
-    default: { fail("unsupported platform ${::osfamily}") }
+    default: { fail("unsupported platform ${$facts['os']['family']}") }
   }
 }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -3,31 +3,31 @@ require 'spec_helper'
 describe 'java', :type => :class do
 
   context 'select openjdk for Centos 5.8' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.8', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '5.8' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.6.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '6.3' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 7.1.1503' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '7.1.1503', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '7.1.1503' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Centos 6.2' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.2', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '6.2' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
 
   context 'select Oracle JRE with alternatives for Centos 6.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '6.3' }, :architecture => 'x86_64'} } }
     let(:params) { { 'package' => 'jre', 'java_alternative' => '/usr/bin/java', 'java_alternative_path' => '/usr/java/jre1.7.0_67/bin/java'} }
     it { is_expected.to contain_package('java').with_name('jre') }
     it { is_expected.to contain_exec('create-java-alternatives').with_command('alternatives --install /usr/bin/java java /usr/java/jre1.7.0_67/bin/java 20000') }
@@ -35,60 +35,60 @@ describe 'java', :type => :class do
   end
 
   context 'select openjdk for Fedora 20' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Fedora', :release => { :full => '20' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select openjdk for Fedora 21' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Fedora', :release => { :full => '21' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Fedora 20' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '20', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Fedora', :release => { :full => '20' }, :architecture => 'x86_64'} } }
     let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/lib/jre/') }
   end
 
   context 'select passed value for Fedora 21' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Fedora', :release => { :full => '21' }, :architecture => 'x86_64'} } }
     let(:params) { { 'distribution' => 'jre', 'java_home' => '/usr/local/lib/jre/' } }
     it { is_expected.to contain_package('java').with_name('java-1.8.0-openjdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/lib/jre/') }
   end
   
   context 'select passed value for Fedora 21 with yum option' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '21', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Fedora', :release => { :full => '21' }, :architecture => 'x86_64'} } }
     let(:params) { { 'distribution' => 'jre' } }
     let(:params) { { 'package_options'  => ['--skip-broken'] } }
     it { is_expected.to contain_package('java') }
   end
 
   context 'select passed value for Centos 5.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '5.3' }, :architecture => 'x86_64'} } }
     let(:params) { { 'package' => 'jdk', 'java_home' => '/usr/local/lib/jre' } }
     it { is_expected.to contain_package('java').with_name('jdk') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
 
   context 'select default for Centos 5.3' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Centos', :operatingsystemrelease => '5.3', :architecture => 'x86_64'} }
+    let(:facts) { { :os => { :family => 'RedHat', :name => 'Centos', :release => { :full => '5.3' }, :architecture => 'x86_64'} } }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
     it { is_expected.to_not contain_exec('update-java-alternatives') }
   end
 
   context 'select default for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/') }
   end
 
   context 'select Oracle JRE for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     let(:params) { { 'distribution' => 'oracle-jre' } }
     it { is_expected.to contain_package('java').with_name('oracle-j2re1.7') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set j2re1.7-oracle --jre') }
@@ -96,14 +96,14 @@ describe 'java', :type => :class do
   end
 
   context 'select Oracle Java 8 JRE >=u100 for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     let(:params) { { 'distribution' => 'oracle-java8-jre' } }
     it { is_expected.to contain_package('java').with_name('oracle-java8-jre') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jre-8-oracle-x64 --jre') }
   end
 
   context 'select Oracle Java 8 JDK >=u100 for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     let(:params) { { 'distribution' => 'oracle-java8-jdk' } }
     it { is_expected.to contain_package('java').with_name('oracle-java8-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set jdk-8-oracle-x64 --jre') }
@@ -111,7 +111,7 @@ describe 'java', :type => :class do
 
 
   context 'select OpenJDK JRE for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-1.7.0-openjdk-amd64 --jre-headless') }
@@ -119,13 +119,13 @@ describe 'java', :type => :class do
   end
 
   context 'select default for Debian Squeeze' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'squeeze' }, :release => { :full => '6.0.5' }, :architecture => 'amd64',} } }
     it { is_expected.to contain_package('java').with_name('openjdk-6-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre') }
   end
 
   context 'select Oracle JRE for Debian Squeeze' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:facts) { {:os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'squeeze' }, :release => { :full => '6.0.5' }, :architecture => 'amd64',} } }
     let(:params) { { 'distribution' => 'sun-jre', } }
     it { is_expected.to contain_package('java').with_name('sun-java6-jre') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-sun --jre') }
@@ -133,7 +133,7 @@ describe 'java', :type => :class do
   end
 
   context 'select OpenJDK JRE for Debian Squeeze' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'squeeze', :operatingsystemrelease => '6.0.5', :architecture => 'amd64',} }
+    let(:facts) { {:os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'squeeze' }, :release => { :full => '6.0.5' }, :architecture => 'amd64',} } }
     let(:params) { { 'distribution' => 'jre', } }
     it { is_expected.to contain_package('java').with_name('openjdk-6-jre-headless') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set java-6-openjdk-amd64 --jre-headless') }
@@ -141,106 +141,106 @@ describe 'java', :type => :class do
   end
 
   context 'select random alternative for Debian Wheezy' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Debian', :lsbdistcodename => 'wheezy', :operatingsystemrelease => '7.1', :architecture => 'amd64',} }
+    let(:facts) { { :os => { :family => 'Debian', :name => 'Debian', :distro => { :codename => 'wheezy' }, :release => { :full => '7.1' }, :architecture => 'amd64' } } }
     let(:params) { { 'java_alternative' => 'bananafish' } }
     it { is_expected.to contain_package('java').with_name('openjdk-7-jdk') }
     it { is_expected.to contain_exec('update-java-alternatives').with_command('update-java-alternatives --set bananafish --jre') }
   end
 
   context 'select jdk for Ubuntu Vivid (15.04)' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
+    let(:facts) { {:os => { :family => 'Debian', :name => 'Ubuntu', :distro => { :codename => 'vivid' }, :release => { :full => '15.04' }, :architecture => 'amd64',} } }
     let(:params) { { 'distribution' => 'jdk' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select jre for Ubuntu Vivid (15.04)' do
-    let(:facts) { {:osfamily => 'Debian', :operatingsystem => 'Ubuntu', :lsbdistcodename => 'vivid', :operatingsystemrelease => '15.04', :architecture => 'amd64',} }
+    let(:facts) { {:os => { :family => 'Debian', :name => 'Ubuntu', :distro => { :codename => 'vivid' }, :release => { :full => '15.04' }, :architecture => 'amd64',} } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('openjdk-8-jre-headless') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
   context 'select openjdk for Amazon Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'Amazon', :release => { :full => '3.4.43-43.43.amzn1.x86_64' }, :architecture => 'x86_64',} } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Amazon Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon', :operatingsystemrelease => '5.3.4.43-43.43.amzn1.x86_64', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'Amazon', :release => { :full => '5.3.4.43-43.43.amzn1.x86_64' }, :architecture => 'x86_64',} } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
   end
 
   context 'select openjdk for Oracle Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'OracleLinux', :release => { :full => '6.4' }, :architecture => 'amd64',} } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk-devel') }
   end
 
   context 'select openjdk for Oracle Linux 6.2' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.2', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'OracleLinux', :release => { :full => '6.2' }, :architecture => 'amd64',} } }
     it { is_expected.to contain_package('java').with_name('java-1.6.0-openjdk-devel') }
   end
 
   context 'select passed value for Oracle Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'OracleLinux', :operatingsystemrelease => '6.3', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'OracleLinux', :release => { :full => '6.3' }, :architecture => 'amd64',} } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
   end
 
   context 'select passed value for Scientific Linux' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Scientific', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'Scientific', :release => { :full => '6.4' }, :architecture => 'x86_64',} } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select passed value for Scientific Linux CERN (SLC)' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'SLC', :operatingsystemrelease => '6.4', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'RedHat', :name => 'SLC', :release => { :full => '6.4' }, :architecture => 'x86_64',} } }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('java-1.7.0-openjdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-x86_64/') }
   end
 
   context 'select default for OpenSUSE 12.3' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'OpenSUSE', :operatingsystemrelease => '12.3', :architecture => 'x86_64'}}
+    let(:facts) { {:os => { :family => 'Suse', :name => 'OpenSUSE', :release => { :full => '12.3' }, :architecture => 'amd64',} } }
     it { is_expected.to contain_package('java').with_name('java-1_7_0-openjdk-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select default for SLES 11.3' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.3', :architecture => 'x86_64'}}
+    let(:facts) { {:os => { :family => 'Suse', :name => 'SLES', :release => { :full => '11.3' }, :architecture => 'x86_64',} } }
     it { should contain_package('java').with_name('java-1_6_0-ibm-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/') }
   end
 
   context 'select default for SLES 11.4' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '11.4', :architecture => 'x86_64'}}
+    let(:facts) { {:os => { :family => 'Suse', :name => 'SLES', :release => { :full => '11.4' }, :architecture => 'x86_64',} } }
     it { should contain_package('java').with_name('java-1_7_1-ibm-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/') }
   end
 
   context 'select default for SLES 12.0' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.0', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
+    let(:facts) { {:os => { :family => 'Suse', :name => 'SLES', :release => { :full => '12.0' }, :architecture => 'x86_64',} } }
     it { should contain_package('java').with_name('java-1_7_0-openjdk-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.0-openjdk-1.7.0/') }
   end
 
   context 'select default for SLES 12.1' do
-    let(:facts) { {:osfamily => 'Suse', :operatingsystem => 'SLES', :operatingsystemrelease => '12.1', :operatingsystemmajrelease => '12', :architecture => 'x86_64'}}
+    let(:facts) { {:os => { :family => 'Suse', :name => 'SLES', :release => { :full => '12.1' }, :architecture => 'x86_64',} } }
     it { should contain_package('java').with_name('java-1_8_0-openjdk-devel')}
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/') }
   end
 
   context 'select jdk for OpenBSD' do
-    let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'OpenBSD'}, :architecture => 'x86_64',} }
     it { is_expected.to contain_package('java').with_name('jdk') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/jdk/') }
   end
 
   context 'select jre for OpenBSD' do
-    let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
+    let(:facts) { {:os => { :family => 'OpenBSD'}, :architecture => 'x86_64',} }
     let(:params) { { 'distribution' => 'jre' } }
     it { is_expected.to contain_package('java').with_name('jre') }
   end
@@ -249,37 +249,57 @@ describe 'java', :type => :class do
     [
       {
         # C14706
-        :osfamily               => 'windows',
-        :operatingsystem        => 'windows',
-        :operatingsystemrelease => '8.1',
+        :os => {
+          :family => 'Windows',
+          :name => 'Windows',
+          :release => {
+            :full => '8.1'
+          }
+        }
       },
       {
         # C14707
-        :osfamily               => 'Darwin',
-        :operatingsystem        => 'Darwin',
-        :operatingsystemrelease => '13.3.0',
+        :os => {
+          :family => 'Darwin',
+          :name => 'Darwin',
+          :release => {
+            :full => '13.3.0'
+          }
+        }
       },
       {
         # C14708
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '7100-02-00-000',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '7100-02-00-000'
+          }
+        }
       },
       {
         # C14708
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '6100-07-04-1216',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '6100-07-04-1216'
+          }
+        }
       },
       {
         # C14708
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '5300-12-01-1016',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '5300-12-01-1016'
+          }
+        }
       },
     ].each do |facts|
       let(:facts) { facts }
-      it "is_expected.to fail on #{facts[:operatingsystem]} #{facts[:operatingsystemrelease]}" do
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
         expect { catalogue }.to raise_error Puppet::Error, /unsupported platform/
       end
     end

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'java::oracle', :type => :define do
     context 'On CentOS 64-bit' do
-      let(:facts) { {:kernel => 'Linux', :architecture => 'x86_64', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+      let(:facts) { { :kernel => 'Linux', :os => {:family => 'RedHat', :architecture => 'x86_64', :name => 'CentOS', :release => {:full => '6.0'}}}}
 
       context 'Oracle Java SE 6 JDK' do
       let(:params) { {:ensure => 'present', :version => '6', :java_se => 'jdk'} }
@@ -55,7 +55,7 @@ describe 'java::oracle', :type => :define do
   end
 
   context 'On CentOS 32-bit' do
-    let(:facts) { {:kernel => 'Linux', :architecture => 'i386', :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '6.6', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)'} }
+    let(:facts) { {:kernel => 'Linux',  :os => { :family => 'RedHat', :architecture => 'i386', :name => 'CentOS', :release => { :full => '6.6' } } } }
 
     context 'select Oracle Java SE 6 JDK on RedHat family, 32-bit' do
       let(:params) { {:ensure => 'present', :version => '6', :java_se => 'jdk'} }
@@ -106,52 +106,67 @@ describe 'java::oracle', :type => :define do
     end
   end
 
-  describe 'incompatible OSs' do
+  describe 'incompatible OSes' do
     [
       {
         # C14706
-        :kernel                 => 'windows',
-        :osfamily               => 'windows',
-        :operatingsystem        => 'windows',
-        :operatingsystemrelease => '8.1',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'Windows',
+        :os => {
+          :family => 'Windows',
+          :name => 'Windows',
+          :release => {
+            :full => '8.1'
+          }
+        },
       },
       {
         # C14707
-        :kernel                 => 'Darwin',
-        :osfamily               => 'Darwin',
-        :operatingsystem        => 'Darwin',
-        :operatingsystemrelease => '13.3.0',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'Darwin',
+        :os => {
+          :family => 'Darwin',
+          :name => 'Darwin',
+          :release => {
+            :full => '13.3.0'
+          }
+        },
       },
       {
         # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '7100-02-00-000',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '7100-02-00-000'
+          }
+        },
       },
       {
-        # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '6100-07-04-1216',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
+        # C14709
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '6100-07-04-1216'
+          }
+        },
       },
       {
-        # C14708
-        :kernel                 => 'AIX',
-        :osfamily               => 'AIX',
-        :operatingsystem        => 'AIX',
-        :operatingsystemrelease => '5300-12-01-1016',
-        :puppetversion          => '3.4.3 (Puppet Enterprise 3.2.3)',
-      },
+        # C14710
+        :kernel => 'AIX',
+        :os => {
+          :family => 'AIX',
+          :name => 'AIX',
+          :release => {
+            :full => '5300-12-01-1016'
+          }
+        },
+      }
     ].each do |facts|
       let(:facts) { facts }
       let :title do 'jdk' end
-      it "is_expected.to fail on #{facts[:operatingsystem]} #{facts[:operatingsystemrelease]}" do
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
         expect { catalogue }.to raise_error Puppet::Error, /unsupported platform/
       end
     end


### PR DESCRIPTION
This PR removes legacy facts from this module. puppet-archive has done so in their latest version and since this module relies on puppet-archive, spec tests fail because those facts are mocked as legacy, not structured facts.