### PR TITLE
MODULES-5058 Allow a complete URL to be passed to the java::oracle class

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -153,6 +153,10 @@ Specify a proxy server, with port number if needed. ie: https://example.com:8080
 
 Proxy server type (none|http|https|ftp). (passed to archive)
 
+##### `url`
+
+Pass an entire URL to download the installer from rather than building the complete URL from other parameters. This will allow the module to be used even if the URLs are changed by Oracle. If this parameter is used, matching `version_major` and `version_minor` parameters must also be passed to the class.
+
 ### Facts
 
 The java module includes a few facts to describe the version of Java installed on the system:
@@ -196,6 +200,8 @@ Oracle Java is supported on:
 * CentOS 6
 
 ### Known issues
+
+Where Oracle change the format of the URLs to different installer packages, the curl to fetch the package may fail with a HTTP/404 error. In this case, passing a full known good URL using the `url` parameter will allow the module to still be able to install specific versions of the JRE/JDK. Note the `version_major` and `version_minor` parameters must be passed and must match the version downloaded using the known URL in the `url` parameter. 
 
 #### OpenBSD
 

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -80,7 +80,8 @@
 #
 # [*url*]
 # Full URL, including oracle_url, release_major, release_minor and package_name, to
-# download the Oracle java_se installer.
+# download the Oracle java_se installer. Originally present but not used, activated
+# to workaround MODULES-5058
 #
 # ### Author
 # mike@marseglia.org
@@ -94,6 +95,7 @@ define java::oracle (
   $oracle_url    = 'http://download.oracle.com/otn-pub/java/jdk/',
   $proxy_server  = undef,
   $proxy_type    = undef,
+  $url           = undef,
 ) {
 
   # archive module is used to download the java package
@@ -196,6 +198,13 @@ define java::oracle (
     }
   }
 
+  # if complete URL is provided, use this value for source in archive resource
+  if $url {
+    $source = $url
+  } else {
+    $source = "${oracle_url}${release_major}-${release_minor}/${package_name}"
+  }
+
   # full path to the installer
   $destination = "${destination_dir}${package_name}"
   notice ("Destination is ${destination}")
@@ -219,7 +228,7 @@ define java::oracle (
     'present' : {
       archive { $destination :
         ensure       => present,
-        source       => "${oracle_url}${release_major}-${release_minor}/${package_name}",
+        source       => $source,
         cookie       => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
         extract_path => '/tmp',
         cleanup      => false,

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -52,6 +52,11 @@ describe 'java::oracle', :type => :define do
         it { is_expected.to contain_exec('Install Oracle java_se jre 8').that_requires('Archive[/tmp/jre-8u51-linux-x64.rpm]') }
     end
 
+    context 'Pass URL to url parameter' do
+      let(:params) { {:ensure => 'present', :version_major => '8u131', :version_minor => 'b11', :java_se => 'jdk', :url => 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm'} }
+      let :title do 'jdk8' end
+        it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-x64.rpm')}
+      end
   end
 
   context 'On CentOS 32-bit' do


### PR DESCRIPTION
This provides a workaround  to the issue of Oracle changing it's URL structure which breaks the dynamic URL building in the module.
It allows a complete URL to be passed as an alternative to one built by the logic in the module, and allows the rest of the module to function as expected when this situation is encountered.

Changes made to manifests/oracle.pp to pass URL in `url` parameter (if defined) to the `source` directive of the archive resource which fetches the installer package.
README.markdown has been updated to document the additional parameter, as well as a note added to known issues describing it's operation.
A test has been added to spec/defines/oracle_spec.rb to verify the correct package is present in the tmp archive location. The spec tests have passed and the revised workflow has been tested in a lab environment and found to be working.