### PR TITLE
Uses File.realpath to resolve the path of /usr/bin/java then returns …

### DIFF
--- a/lib/facter/java_default_home.rb
+++ b/lib/facter/java_default_home.rb
@@ -3,25 +3,23 @@
 # Purpose: get absolute path of java system home
 #
 # Resolution:
-#   Uses `readlink` to resolve the path of `/usr/bin/java` then returns subsubdir
-#
-# Caveats:
-#   Requires readlink
+#   Uses File.realpath to resolve the path of `/usr/bin/java` then returns subsubdir
 #
 # Notes:
 #   None
 Facter.add(:java_default_home) do
   confine :kernel => 'Linux'
   setcode do
-    if Facter::Util::Resolution.which('readlink')
-      java_bin = Facter::Util::Resolution.exec('readlink -e /usr/bin/java').strip
-      if java_bin.empty?
-        nil
-      elsif java_bin =~ %r(/jre/)
+    if File.exist?('/usr/bin/java')
+      java_bin = File.realpath("/usr/bin/java")
+      java_default_home = File.dirname(File.dirname(File.dirname(java_bin)))
+      if java_bin =~ %r(/jre/)
         java_default_home = File.dirname(File.dirname(File.dirname(java_bin)))
       else
         java_default_home = File.dirname(File.dirname(java_bin))
       end
+    else
+      java_default_home = ''
     end
   end
 end


### PR DESCRIPTION
Topic: fact java_default_home needs to improve
Ticket: https://tickets.puppetlabs.com/browse/MODULES-5115

Uses File.realpath to resolve the path of /usr/bin/java and does not affect other facts
in case /usr/bin/java does not exist