### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,13 +45,13 @@
 # Sample Usage:
 #
 class java(
-  String $distribution                                              = 'jdk',
-  Pattern[/present|installed|latest|^[.+_0-9a-zA-Z:~-]+$/] $version = 'present',
-  Optional[String] $package                                         = undef,
-  Optional[Array] $package_options                                  = undef,
-  Optional[String] $java_alternative                                = undef,
-  Optional[String] $java_alternative_path                           = undef,
-  Optional[String] $java_home                                       = undef
+  $distribution           = 'jdk',
+  $version                = 'present',
+  $package                = undef,
+  $package_options        = undef,
+  $java_alternative       = undef,
+  $java_alternative_path  = undef,
+  $java_home              = undef
 ) {
   include java::params
 


### PR DESCRIPTION
Removed comments that where put in front of java class variables.
Resulting in the following error message:
"Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at 'String'; expected ')' at /etc/puppet/modules/java/manifests/init.pp:49 on node localhost.doamin Warning: Not using cache on failed catalog Error: Could not retrieve catalog; skipping run"