### PR TITLE
Removing Debian 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
According to the followin page Debian 6 is no longer supported as an
Agent. https://docs.puppet.com/pe/latest/sys_req_os.html