### PR TITLE
(FACT-1754) search for matching line with java version

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -22,10 +22,11 @@ Facter.add(:java_version) do
   # positive matches, so this needs to be done manually in setcode.
   setcode do
     unless [ 'openbsd', 'darwin' ].include? Facter.value(:operatingsystem).downcase
+      version = nil
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
-        nil
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $~[1] if /^.+ version \"(.+)\"$/ =~ line }
       end
+      version
     end
   end
 end
@@ -35,10 +36,11 @@ Facter.add(:java_version) do
   has_weight 100
   setcode do
     Facter::Util::Resolution.with_env("PATH" => '/usr/local/jdk-1.7.0/jre/bin:/usr/local/jre-1.7.0/bin') do
+      version = nil
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
-        nil
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $~[1] if /^.+ version \"(.+)\"$/ =~ line }
       end
+      version
     end
   end
 end
@@ -48,8 +50,9 @@ Facter.add(:java_version) do
   has_weight 100
   setcode do
     unless /Unable to find any JVMs matching version/ =~ Facter::Util::Resolution.exec('/usr/libexec/java_home --failfast 2>&1')
-      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
-      nil
+      version = nil
+      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $~[1] if /^.+ version \"(.+)\"$/ =~ line }
+      version
     end
   end
 end

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -23,7 +23,8 @@ Facter.add(:java_version) do
   setcode do
     unless [ 'openbsd', 'darwin' ].include? Facter.value(:operatingsystem).downcase
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
+        nil
       end
     end
   end
@@ -35,7 +36,8 @@ Facter.add(:java_version) do
   setcode do
     Facter::Util::Resolution.with_env("PATH" => '/usr/local/jdk-1.7.0/jre/bin:/usr/local/jre-1.7.0/bin') do
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
+        nil
       end
     end
   end
@@ -46,7 +48,8 @@ Facter.add(:java_version) do
   has_weight 100
   setcode do
     unless /Unable to find any JVMs matching version/ =~ Facter::Util::Resolution.exec('/usr/libexec/java_home --failfast 2>&1')
-      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.first.split(/"/)[1].strip
+      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.lines.each { |line| return $~[1] if /^java version \"(.+)\"$/ =~ line }
+      nil
     end
   end
 end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -14,6 +14,7 @@ describe Facter::Util::Fact do
         let(:facts) { {:operatingsystem => 'OpenBSD'} }
         it do
           java_version_output = <<-EOS
+Picked up JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
 openjdk version "1.7.0_71"
 OpenJDK Runtime Environment (build 1.7.0_71-b14)
 OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
@@ -30,6 +31,7 @@ OpenJDK 64-Bit Server VM (build 24.71-b01, mixed mode)
         let(:facts) { {:operatingsystem => 'Darwin'} }
         it do
           java_version_output = <<-EOS
+Picked up JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
 java version "1.7.0_71"
 Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
@@ -46,6 +48,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
         let(:facts) { {:operatingsystem => 'MyOS'} }
         it do
           java_version_output = <<-EOS
+Picked up JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
 java version "1.7.0_71"
 Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)


### PR DESCRIPTION
FACT-1754: fact "java_version" fails when JAVA_TOOL_OPTIONS is used

Solution: do not just try to read java version from first line, but search for the matching line from java output.

Note: as in the original code, the fix appears three times - I think it is on purpose to not introduce new functions in this scope.
