### PR TITLE
unbreak on OpenBSD

### DIFF
--- a/lib/facter/java_default_home.rb
+++ b/lib/facter/java_default_home.rb
@@ -11,13 +11,20 @@
 # Notes:
 #   None
 Facter.add(:java_default_home) do
-  confine :kernel => 'Linux'
+  confine :kernel => [ 'Linux', 'OpenBSD' ]
   setcode do
     if Facter::Util::Resolution.which('readlink')
-      java_bin = Facter::Util::Resolution.exec('readlink -e /usr/bin/java').strip
+      java_bin = Facter::Util::Resolution.exec('readlink -e /usr/bin/java').to_s.strip
       if java_bin.empty?
-        nil
-      elsif java_bin =~ %r(/jre/)
+        java_bin = Facter::Util::Resolution.exec('readlink -e /usr/local/bin/java').to_s.strip
+        if java_bin.empty?
+          java_bin = Facter::Util::Resolution.which('java').to_s.strip
+          if java_bin.empty?
+            nil
+          end
+        end
+      end
+      if java_bin =~ %r(/jre/)
         java_default_home = File.dirname(File.dirname(File.dirname(java_bin)))
       else
         java_default_home = File.dirname(File.dirname(java_bin))

--- a/lib/facter/java_default_home.rb
+++ b/lib/facter/java_default_home.rb
@@ -3,27 +3,22 @@
 # Purpose: get absolute path of java system home
 #
 # Resolution:
-#   Uses `readlink` to resolve the path of `/usr/bin/java` then returns subsubdir
+#   Find the real java binary, and return the subsubdir
 #
 # Caveats:
-#   Requires readlink
+#   java binary has to be found in $PATH
 #
 # Notes:
 #   None
 Facter.add(:java_default_home) do
   confine :kernel => [ 'Linux', 'OpenBSD' ]
   setcode do
-    if Facter::Util::Resolution.which('readlink')
-      java_bin = Facter::Util::Resolution.exec('readlink -e /usr/bin/java').to_s.strip
-      if java_bin.empty?
-        java_bin = Facter::Util::Resolution.exec('readlink -e /usr/local/bin/java').to_s.strip
-        if java_bin.empty?
-          java_bin = Facter::Util::Resolution.which('java').to_s.strip
-          if java_bin.empty?
-            nil
-          end
-        end
-      end
+    java_bin = Facter::Util::Resolution.which('java').to_s.strip
+    if java_bin.empty?
+      nil
+    else
+      # We might have found a symlink instead of the real binary
+      java_bin = File.realpath(java_bin)
       if java_bin =~ %r(/jre/)
         java_default_home = File.dirname(File.dirname(File.dirname(java_bin)))
       else

--- a/lib/facter/java_libjvm_path.rb
+++ b/lib/facter/java_libjvm_path.rb
@@ -11,7 +11,7 @@
 # Notes:
 #   None
 Facter.add(:java_libjvm_path) do
-  confine :kernel => "Linux"
+  confine :kernel => [ "Linux", "OpenBSD" ]
   setcode do
     java_default_home = Facter.value(:java_default_home)
     java_libjvm_file = Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -21,21 +21,7 @@ Facter.add(:java_version) do
   # Additionally, facter versions prior to 2.0.1 only support
   # positive matches, so this needs to be done manually in setcode.
   setcode do
-    unless [ 'openbsd', 'darwin' ].include? Facter.value(:operatingsystem).downcase
-      version = nil
-      if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $~[1] if /^.+ version \"(.+)\"$/ =~ line }
-      end
-      version
-    end
-  end
-end
-
-Facter.add(:java_version) do
-  confine :operatingsystem => 'OpenBSD'
-  has_weight 100
-  setcode do
-    Facter::Util::Resolution.with_env("PATH" => '/usr/local/jdk-1.7.0/jre/bin:/usr/local/jre-1.7.0/bin') do
+    unless [ 'darwin' ].include? Facter.value(:operatingsystem).downcase
       version = nil
       if Facter::Util::Resolution.which('java')
         Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $~[1] if /^.+ version \"(.+)\"$/ =~ line }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class java::config ( ) {
         }
       }
     }
-    'OpenBSD', 'FreeBSD', 'Suse': {
+    'FreeBSD', 'Suse': {
       if $java::use_java_home != undef {
         file_line { 'java-home-environment':
           path  => '/etc/environment',

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,13 @@
       "operatingsystemrelease": [
         "11"
       ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "6.1",
+        "6.2"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -236,7 +236,7 @@ describe 'java', :type => :class do
   context 'select jdk for OpenBSD' do
     let(:facts) { {:osfamily => 'OpenBSD', :architecture => 'x86_64'} }
     it { is_expected.to contain_package('java').with_name('jdk') }
-    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/local/jdk/') }
+    it { is_expected.to_not contain_file_line('java-home-environment') }
   end
 
   context 'select jre for OpenBSD' do

--- a/spec/unit/facter/java_default_home_spec.rb
+++ b/spec/unit/facter/java_default_home_spec.rb
@@ -1,47 +1,43 @@
 require "spec_helper"
 
 describe Facter::Util::Fact do
-  before {
-    Facter.clear
-    Facter.fact(:kernel).stubs(:value).returns('Linux')
-  }
 
   describe "java_default_home" do
-    context 'returns java home path when readlink present' do
-      context 'when java is in HOME/jre/bin/java' do
+    before(:each) {
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns('Linux')
+    }
+
+    context 'returns java home path when java found in PATH' do
+      context "when java is in /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java" do
+
         it do
-          java_path_output = <<-EOS
-/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-          EOS
-          Facter::Util::Resolution.expects(:which).with("readlink").returns(true)
-          Facter::Util::Resolution.expects(:exec).with("readlink -e /usr/bin/java").returns(java_path_output)
-          expect(Facter.value(:java_default_home)).to eql "/usr/lib/jvm/java-7-openjdk-amd64"
+          File.delete('./java') if File.exist?('./java')
+          File.symlink('/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java', './java')
+          Facter::Util::Resolution.expects(:which).with("java").returns("./java")
+          expect(File.readlink('./java')).to eq('/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java')
+          expect(Facter.value(:java_default_home)).to eql '/usr/lib/jvm/java-7-openjdk-amd64'
+          File.delete('./java') if File.exist?('./java')
         end
       end
-      context 'when java is in HOME/bin/java' do
+
+      context "when java is in /usr/lib/jvm/oracle-java8-jre-amd64/bin/java" do
+
         it do
-          java_path_output = <<-EOS
-/usr/lib/jvm/oracle-java8-jre-amd64/bin/java
-          EOS
-          Facter::Util::Resolution.expects(:which).with("readlink").returns(true)
-          Facter::Util::Resolution.expects(:exec).with("readlink -e /usr/bin/java").returns(java_path_output)
-          expect(Facter.value(:java_default_home)).to eql "/usr/lib/jvm/oracle-java8-jre-amd64"
+          File.delete('./java') if File.exist?('./java')
+          File.symlink('/usr/lib/jvm/oracle-java8-jre-amd64/bin/java', './java')
+          Facter::Util::Resolution.expects(:which).with("java").returns("./java")
+          expect(File.readlink('./java')).to eq('/usr/lib/jvm/oracle-java8-jre-amd64/bin/java')
+          expect(Facter.value(:java_default_home)).to eql '/usr/lib/jvm/oracle-java8-jre-amd64'
+          File.delete('./java') if File.exist?('./java')
         end
-      end
-    end
-    context 'returns nil when readlink is present but java is not' do
-      it do
-        java_path_output = ""
-        Facter::Util::Resolution.expects(:which).with("readlink").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("readlink -e /usr/bin/java").returns(java_path_output)
-        expect(Facter.value(:java_default_home)).to be_nil
       end
     end
 
-    context 'returns nil when readlink not present' do
+    context 'returns nil when java not present' do
       it do
         Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with("readlink").at_least(1).returns(false)
+        Facter::Util::Resolution.expects(:which).with("java").at_least(1).returns(false)
         expect(Facter.value(:java_default_home)).to be_nil
       end
     end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Util::Fact do
 
   describe "java_version" do
     context 'returns java version when java present' do
-      context 'on OpenBSD', :with_env => true do
+      context 'on OpenBSD' do
         before do
           Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
         end
@@ -61,7 +61,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
     end
 
     context 'returns nil when java not present' do
-      context 'on OpenBSD', :with_env => true do
+      context 'on OpenBSD' do
         before do
           Facter.fact(:operatingsystem).stubs(:value).returns("OpenBSD")
         end


### PR DESCRIPTION
    OpenBSD doesn't have /etc/environment, therefore there is no
    need to fiddle with it. The default case statement, "do nothing"
    is all fine here.
    
    Facter::Util::Resolution.with_env is long time gone since
    Facter > 2.x. That was even longer before introduced by me.
    Remove that OpenBSD special case in the java_version fact,
    and assume that $PATH is properly set in order to find
    the 'java' binary.
    
    Additionally confine the java_default_home and java_libjvm_path
    to OpenBSD kernel as well. If I see posix specs right, 'readlink'
    utility is not mentioned there, and the '-e' flag is not portable,
    at least not available on the OpenBSD readlink binary.
    Because of that, I switched that fact to use Ruby functions to
    find the real path of the java binary.
    I adapted the tests, but that drives me crazy, I cannot remember
    how many attempts I made to get them all to be green.
    With the current state, only one is failing for the java_default_home,
    but I have no clue what's wrong with it. Any hint/help to get it
    right would be much appreciated.


