### PR TITLE
Add support for Ubuntu artful (17.10) and bionic (18.04 to be)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,7 +155,7 @@ class java::params {
             },
           }
         }
-        'stretch', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty': {
+        'stretch', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic': {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-8-jdk',


### PR DESCRIPTION
Maybe it would be smarter to default 18.04 to 9 (which will definitely ship in 18.04).  But this is the conservative approach.

It is a little annoying that the module fails outright on unspecified versions of the OS, but I understand the difficulties in doing otherwise.