### PR TITLE
MODULE-6105: Move `.sync.yml` travis configuration under `.travis.yml:`

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,7 @@ appveyor.yml:
   delete: true
 spec/spec_helper.rb:
   allow_deprecations: true
-extras:
-- rvm: 2.1.9
-  script: bundle exec rake rubocop
+.travis.yml:
+  extras:
+  - rvm: 2.1.9
+    script: bundle exec rake rubocop


### PR DESCRIPTION
This will allow `modulesync` to work again for this module.