### PR TITLE
Remove ensure_resource to avoid potential conflict

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -106,8 +106,6 @@ define java::oracle (
   # archive module is used to download the java package
   include ::archive
 
-  ensure_resource('class', 'stdlib')
-
   # validate java Standard Edition to download
   if $java_se !~ /(jre|jdk)/ {
     fail('Java SE must be either jre or jdk.')


### PR DESCRIPTION
This was probably unintended and could cause conflicts where
stdlib::stages isn't desired.