### PR TITLE
MODULES-7819 fix set JAVA_HOME environments on FreeBSD platform

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,12 +44,26 @@ class java::config ( ) {
         }
       }
     }
-    'FreeBSD', 'Suse': {
+    'Suse': {
       if $java::use_java_home != undef {
         file_line { 'java-home-environment':
           path  => '/etc/environment',
           line  => "JAVA_HOME=${$java::use_java_home}",
           match => 'JAVA_HOME=',
+        }
+      }
+    }
+    'FreeBSD': {
+      if $java::use_java_home != undef {
+        file_line { 'java-home-environment-profile':
+          path  => '/etc/profile',
+          line  => "JAVA_HOME=${$java::use_java_home}; export JAVA_HOME",
+          match => 'JAVA_HOME=',
+        }
+        file_line { 'java-home-environment-cshrc':
+          path  => '/etc/csh.login',
+          line  => "setenv JAVA_HOME ${$java::use_java_home}",
+          match => 'setenv JAVA_HOME',
         }
       }
     }


### PR DESCRIPTION
FreeBSD do not use /etc/environment file for global variables. Instead we use two
places to set the variable:
  - /etc/profile for sh(1)
  - /etc/csh.login for csh(1) which is the default shell for FreeBSD

Fixes for MODULES-7819 issue