### PR TITLE
(MODULES-7050) - Fix OracleJDK reinstalling on Puppet runs

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -119,7 +119,13 @@ define java::oracle (
     $release_hash  = $url_hash
 
     if $release_major =~ /(\d+)u(\d+)/ {
-      $install_path = "${java_se}1.${1}.0_${2}"
+      # Required for CentOS systems where Java8 update number is >= 171 to ensure
+      # the package is visible to Puppet
+      if $facts['os']['name'] == 'CentOS' and $2 >= '171' {
+        $install_path = "${java_se}1.${1}.0_${2}-amd64"
+      } else {
+        $install_path = "${java_se}1.${1}.0_${2}"
+      }
     } else {
       $install_path = "${java_se}${release_major}${release_minor}"
     }


### PR DESCRIPTION
On CentOS, OracleJDK has renamed builds from JDK8 Update 171 to suffix `-amd64`. This caused the JDK to be reinstalled on every Puppet run as it could not find install path. This change amends the directory path to include the suffix, thus preventing Puppet reinstalling the JDK. Additional details can be found on the [ticket](https://tickets.puppetlabs.com/browse/MODULES-7050).