### PR TITLE
Support for installing JCE. Fixes MODULES-1681

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -134,7 +134,7 @@ define java::oracle (
     if $release_major =~ /(\d+)u(\d+)/ {
       # Required for CentOS systems where Java8 update number is >= 171 to ensure
       # the package is visible to Puppet
-      if $facts['os']['name'] == 'CentOS' and $2 >= '171' {
+      if $facts['os']['family'] == 'RedHat' and $2 >= '171' {
         $install_path = "${java_se}1.${1}.0_${2}-amd64"
       } else {
         $install_path = "${java_se}1.${1}.0_${2}"

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -322,7 +322,7 @@ define java::oracle (
               proxy_type    => $proxy_type,
               require       => [
                 Package['unzip'],
-                Exec["Install Oracle java_se ${java_se} ${version}"]
+                Exec["Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}"]
               ]
             }
           }

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -269,20 +269,22 @@ define java::oracle (
       }
       case $facts['kernel'] {
         'Linux' : {
-          exec { "Install Oracle java_se ${java_se} ${version}" :
+          case $facts['os']['family'] {
+            'Debian' : {
+              ensure_resource('file', '/usr/lib/jvm', {
+                ensure => directory,
+              })
+              $install_requires = [Archive[$destination], File['/usr/lib/jvm']]
+            }
+            default : {
+              $install_requires = [Archive[$destination]]
+            }
+          }
+          exec { "Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
             command => $install_command,
             creates => $creates_path,
-            require => Archive[$destination]
-          }
-          case $facts['os']['family'] {
-            'Debian' : {
-              file{'/usr/lib/jvm':
-                ensure => directory,
-                before => Exec["Install Oracle java_se ${java_se} ${version}"]
-              }
-            }
-            default : { }
+            require => $install_requires
           }
         }
         default : {

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -87,6 +87,9 @@
 # Directory hash used by the download.oracle.com site.  This value is a 32 character string
 # which is part of the file URL returned by the JDK download site.
 #
+# [*jce*]
+# Install Oracles Java Cryptographic Extensions into the JRE or JDK
+#
 # ### Author
 # mike@marseglia.org
 #
@@ -101,6 +104,7 @@ define java::oracle (
   $proxy_type    = undef,
   $url           = undef,
   $url_hash      = undef,
+  $jce           = false,
 ) {
 
   # archive module is used to download the java package
@@ -109,6 +113,15 @@ define java::oracle (
   # validate java Standard Edition to download
   if $java_se !~ /(jre|jdk)/ {
     fail('Java SE must be either jre or jdk.')
+  }
+
+  if $jce {
+    $jce_download = $version ? {
+      '8'     => 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip',
+      '7'     => 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip',
+      '6'     => 'http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip',
+      default => undef
+    }
   }
 
   # determine Oracle Java major and minor version, and installation path
@@ -185,6 +198,11 @@ define java::oracle (
     }
     default : {
       fail ( "unsupported platform ${$facts['kernel']}" ) }
+  }
+
+  # Install required unzip packages for jce
+  if $jce {
+    ensure_resource('package', 'unzip', { 'ensure' => 'present' })
   }
 
   # set java architecture nomenclature
@@ -285,6 +303,28 @@ define java::oracle (
             command => $install_command,
             creates => $creates_path,
             require => $install_requires
+          }
+
+          if ($jce and $jce_download != undef) {
+            $jce_path = $java_se ? {
+              'jre' => "${creates_path}/lib/security",
+              'jdk' => "${creates_path}/jre/lib/security"
+            }
+            archive { "/tmp/jce-${version}.zip":
+              source        => $jce_download,
+              cookie        => 'gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie',
+              extract       => true,
+              extract_path  => $jce_path,
+              extract_flags => '-oj',
+              creates       => "${jce_path}/US_export_policy.jar",
+              cleanup       => false,
+              proxy_server  => $proxy_server,
+              proxy_type    => $proxy_type,
+              require       => [
+                Package['unzip'],
+                Exec["Install Oracle java_se ${java_se} ${version}"]
+              ]
+            }
           }
         }
         default : {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,7 +155,7 @@ class java::params {
             },
           }
         }
-        'stretch', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic': {
+        'stretch', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty', 'artful': {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-8-jdk',
@@ -168,6 +168,22 @@ class java::params {
               'alternative'      => "java-1.8.0-openjdk-${::architecture}",
               'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
               'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+            }
+          }
+        }
+        'bionic': {
+          $java =  {
+            'jdk' => {
+              'package'          => 'openjdk-11-jdk',
+              'alternative'      => "java-1.11.0-openjdk-${::architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/",
+            },
+            'jre' => {
+              'package'          => 'openjdk-11-jre-headless',
+              'alternative'      => "java-1.11.0-openjdk-${::architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/",
             }
           }
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,18 +74,23 @@ class java::params {
         'amd64' => 'x64',
         default => $::architecture
       }
+      $openjdk_architecture = $::architecture ? {
+        'aarch64' => 'arm64',
+        'armv7l'  => 'armhf',
+        default   => $::architecture
+      }
       case $::lsbdistcodename {
         'lenny', 'squeeze', 'lucid', 'natty': {
           $java  = {
             'jdk' => {
               'package'          => 'openjdk-6-jdk',
-              'alternative'      => "java-6-openjdk-${::architecture}",
+              'alternative'      => "java-6-openjdk-${openjdk_architecture}",
               'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
               'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
             },
             'jre' => {
               'package'          => 'openjdk-6-jre-headless',
-              'alternative'      => "java-6-openjdk-${::architecture}",
+              'alternative'      => "java-6-openjdk-${openjdk_architecture}",
               'alternative_path' => '/usr/lib/jvm/java-6-openjdk/jre/bin/java',
               'java_home'        => '/usr/lib/jvm/java-6-openjdk/jre/',
             },
@@ -107,15 +112,15 @@ class java::params {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-7-jdk',
-              'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.7.0-openjdk-${openjdk_architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${openjdk_architecture}/",
             },
             'jre' => {
               'package'          => 'openjdk-7-jre-headless',
               'alternative'      => "java-1.7.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${::architecture}/",
+              'alternative_path' => "/usr/lib/jvm/java-1.7.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.7.0-openjdk-${openjdk_architecture}/",
             },
             'oracle-jre' => {
               'package'          => 'oracle-j2re1.7',
@@ -159,15 +164,15 @@ class java::params {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-8-jdk',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.8.0-openjdk-${openjdk_architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${openjdk_architecture}/",
             },
             'jre' => {
               'package'          => 'openjdk-8-jre-headless',
-              'alternative'      => "java-1.8.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.8.0-openjdk-${openjdk_architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.8.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.8.0-openjdk-${openjdk_architecture}/",
             }
           }
         }
@@ -175,15 +180,15 @@ class java::params {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-11-jdk',
-              'alternative'      => "java-1.11.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.11.0-openjdk-${openjdk_architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${openjdk_architecture}/",
             },
             'jre' => {
               'package'          => 'openjdk-11-jre-headless',
-              'alternative'      => "java-1.11.0-openjdk-${::architecture}",
-              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/bin/java",
-              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${::architecture}/",
+              'alternative'      => "java-1.11.0-openjdk-${openjdk_architecture}",
+              'alternative_path' => "/usr/lib/jvm/java-1.11.0-openjdk-${openjdk_architecture}/bin/java",
+              'java_home'        => "/usr/lib/jvm/java-1.11.0-openjdk-${openjdk_architecture}/",
             }
           }
         }

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -86,10 +86,10 @@ bogus_alternative = "class { 'java':\n"\
 # enable the tests:
 
 oracle_enabled = false
-oracle_version_major = "8"
-oracle_version_minor = "181"
-oracle_version_build = "13"
-oracle_hash = "96a7b8442fe848ef90c96a2fad6ed6d1"
+oracle_version_major = '8'
+oracle_version_minor = '181'
+oracle_version_build = '13'
+oracle_hash = '96a7b8442fe848ef90c96a2fad6ed6d1'
 
 install_oracle_jre = <<EOL
   java::oracle {
@@ -216,11 +216,11 @@ end
 
 # Test oracle java installs
 context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
-  install_path = "/usr/lib/jvm"
-  version_suffix = ""
-  if fact('osfamily') == 'RedHat' || fact('osfamily') == 'Amazon' then
-    install_path = "/usr/java"
-    version_suffix = "-amd64"
+  install_path = '/usr/lib/jvm'
+  version_suffix = ''
+  if fact('osfamily') == 'RedHat' || fact('osfamily') == 'Amazon'
+    install_path = '/usr/java'
+    version_suffix = '-amd64'
   end
   it 'installs oracle jdk' do
     apply_manifest(install_oracle_jdk, catch_failures: true)

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper_acceptance'
 
+include Unix::File
+
 # RedHat, CentOS, Scientific, Oracle prior to 5.0  : Sun Java JDK/JRE 1.6
 # RedHat, CentOS, Scientific, Oracle 5.0 < x < 6.3 : OpenJDK Java JDK/JRE 1.6
 # RedHat, CentOS, Scientific, Oracle after 6.3     : OpenJDK Java JDK/JRE 1.7
@@ -79,6 +81,62 @@ bogus_alternative = "class { 'java':\n"\
                     "  java_alternative_path => '/whatever',\n"\
                     '}'
 
+# Oracle installs are disabled by default, because the links to valid oracle installations
+# change often. Look the parameters up from the Oracle download URLs at https://java.oracle.com and
+# enable the tests:
+
+oracle_enabled = true
+oracle_version_major = "8"
+oracle_version_minor = "181"
+oracle_version_build = "13"
+oracle_hash = "96a7b8442fe848ef90c96a2fad6ed6d1"
+
+install_oracle_jre = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jre',
+  }
+EOL
+
+install_oracle_jdk = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jdk',
+  }
+EOL
+
+install_oracle_jre_jce = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jre',
+      jce           => true,
+  }
+EOL
+
+install_oracle_jdk_jce = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jdk',
+      jce           => true,
+  }
+EOL
+
 context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'installs jre' do
     apply_manifest(java_class_jre, catch_failures: true)
@@ -153,5 +211,39 @@ context 'with failure cases' do
     else
       apply_manifest(bogus_alternative, catch_failures: true)
     end
+  end
+end
+
+# Test oracle java installs
+context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  install_path = "/usr/lib/jvm"
+  version_suffix = ""
+  if fact('osfamily') == 'RedHat' || fact('osfamily') == 'Amazon' then
+    install_path = "/usr/java"
+    version_suffix = "-amd64"
+  end
+  it 'installs oracle jdk' do
+    apply_manifest(install_oracle_jdk, catch_failures: true)
+    apply_manifest(install_oracle_jdk, catch_changes: true)
+    result = shell("test ! -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
+  end
+  it 'installs oracle jre' do
+    apply_manifest(install_oracle_jre, catch_failures: true)
+    apply_manifest(install_oracle_jre, catch_changes: true)
+    result = shell("test ! -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
+  end
+  it 'installs oracle jdk with jce' do
+    apply_manifest(install_oracle_jdk_jce, catch_failures: true)
+    apply_manifest(install_oracle_jdk_jce, catch_changes: true)
+    result = shell("test -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
+  end
+  it 'installs oracle jre with jce' do
+    apply_manifest(install_oracle_jre_jce, catch_failures: true)
+    apply_manifest(install_oracle_jre_jce, catch_changes: true)
+    result = shell("test -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
   end
 end

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -104,7 +104,7 @@ EOL
 
 install_oracle_jdk = <<EOL
   java::oracle {
-    'test_oracle_jre':
+    'test_oracle_jdk':
       version       => '#{oracle_version_major}',
       version_major => '#{oracle_version_major}u#{oracle_version_minor}',
       version_minor => 'b#{oracle_version_build}',
@@ -127,7 +127,7 @@ EOL
 
 install_oracle_jdk_jce = <<EOL
   java::oracle {
-    'test_oracle_jre':
+    'test_oracle_jdk':
       version       => '#{oracle_version_major}',
       version_major => '#{oracle_version_major}u#{oracle_version_minor}',
       version_minor => 'b#{oracle_version_build}',

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -85,7 +85,7 @@ bogus_alternative = "class { 'java':\n"\
 # change often. Look the parameters up from the Oracle download URLs at https://java.oracle.com and
 # enable the tests:
 
-oracle_enabled = true
+oracle_enabled = false
 oracle_version_major = "8"
 oracle_version_minor = "181"
 oracle_version_build = "13"

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -69,6 +69,22 @@ describe 'java', type: :class do
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/') }
   end
 
+  context 'when select jdk for Ubuntu xenial (16.04) on ARM' do
+    let(:facts) { { osfamily: 'Debian', operatingsystem: 'Ubuntu', lsbdistcodename: 'xenial', operatingsystemrelease: '16.04', architecture: 'armv7l' } }
+    let(:params) { { 'distribution' => 'jdk' } }
+
+    it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-armhf/') }
+  end
+
+  context 'when select jdk for Ubuntu xenial (16.04) on ARM64' do
+    let(:facts) { { osfamily: 'Debian', operatingsystem: 'Ubuntu', lsbdistcodename: 'xenial', operatingsystemrelease: '16.04', architecture: 'aarch64' } }
+    let(:params) { { 'distribution' => 'jdk' } }
+
+    it { is_expected.to contain_package('java').with_name('openjdk-8-jdk') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-arm64/') }
+  end
+
   context 'when select openjdk for Amazon Linux' do
     let(:facts) { { osfamily: 'RedHat', operatingsystem: 'Amazon', operatingsystemrelease: '3.4.43-43.43.amzn1.x86_64', architecture: 'x86_64' } }
 

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -123,8 +123,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JRE with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jre1.6.0_99-amd64/lib/security')
@@ -132,8 +133,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JDK with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jdk1.6.0_99-amd64/jre/lib/security')
@@ -227,8 +229,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JRE with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jre1.6.0_99-amd64/lib/security')
@@ -236,8 +239,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JDK with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jdk1.6.0_99-amd64/jre/lib/security')
@@ -338,8 +342,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JRE with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/lib/jvm/jre1.6.0_99/lib/security')
@@ -347,8 +352,9 @@ describe 'java::oracle', type: :define do
     end
 
     context 'when installing Oracle Java SE 6 JDK with JCE' do
-      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
-      let(:title) { 'jre6jce'}
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk' } }
+      let(:title) { 'jre6jce' }
+
       it do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/lib/jvm/jdk1.6.0_99/jre/lib/security')

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -121,6 +121,24 @@ describe 'java::oracle', type: :define do
 
       it { is_expected.to compile }
     end
+
+    context 'when installing Oracle Java SE 6 JRE with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jre1.6.0_99-amd64/lib/security')
+      end
+    end
+
+    context 'when installing Oracle Java SE 6 JDK with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jdk1.6.0_99-amd64/jre/lib/security')
+      end
+    end
   end
 
   context 'when on CentOS 32-bit' do
@@ -206,6 +224,24 @@ describe 'java::oracle', type: :define do
       end
 
       it { is_expected.to compile }
+    end
+
+    context 'when installing Oracle Java SE 6 JRE with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jre1.6.0_99-amd64/lib/security')
+      end
+    end
+
+    context 'when installing Oracle Java SE 6 JDK with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jdk1.6.0_99-amd64/jre/lib/security')
+      end
     end
   end
 
@@ -299,6 +335,24 @@ describe 'java::oracle', type: :define do
       end
 
       it { is_expected.to compile }
+    end
+
+    context 'when installing Oracle Java SE 6 JRE with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jre'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/lib/jvm/jre1.6.0_99/lib/security')
+      end
+    end
+
+    context 'when installing Oracle Java SE 6 JDK with JCE' do
+      let(:params) { { ensure: 'present', jce: true, version: '6', version_major: '6u99', version_minor: '99', java_se: 'jdk'}}
+      let(:title) { 'jre6jce'}
+      it do
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_source('http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip')
+        is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/lib/jvm/jdk1.6.0_99/jre/lib/security')
+      end
     end
   end
   describe 'incompatible OSes' do

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -11,8 +11,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk6' }
 
       it { is_expected.to contain_archive('/tmp/jdk-6u45-linux-x64-rpm.bin') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').with_command('sh /tmp/jdk-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').that_requires('Archive[/tmp/jdk-6u45-linux-x64-rpm.bin]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').with_command('sh /tmp/jdk-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').that_requires('Archive[/tmp/jdk-6u45-linux-x64-rpm.bin]') }
     end
 
     context 'when Oracle Java SE 7 JDK' do
@@ -20,8 +20,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk7' }
 
       it { is_expected.to contain_archive('/tmp/jdk-7u80-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').with_command('rpm --force -iv /tmp/jdk-7u80-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').that_requires('Archive[/tmp/jdk-7u80-linux-x64.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').with_command('rpm --force -iv /tmp/jdk-7u80-linux-x64.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').that_requires('Archive[/tmp/jdk-7u80-linux-x64.rpm]') }
     end
 
     context 'when Oracle Java SE 8 JDK' do
@@ -29,8 +29,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk8' }
 
       it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').with_command('rpm --force -iv /tmp/jdk-8u131-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').that_requires('Archive[/tmp/jdk-8u131-linux-x64.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').with_command('rpm --force -iv /tmp/jdk-8u131-linux-x64.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').that_requires('Archive[/tmp/jdk-8u131-linux-x64.rpm]') }
     end
 
     context 'when Oracle Java SE 6 JRE' do
@@ -38,8 +38,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre6' }
 
       it { is_expected.to contain_archive('/tmp/jre-6u45-linux-x64-rpm.bin') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').with_command('sh /tmp/jre-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').that_requires('Archive[/tmp/jre-6u45-linux-x64-rpm.bin]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').with_command('sh /tmp/jre-6u45-linux-x64-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').that_requires('Archive[/tmp/jre-6u45-linux-x64-rpm.bin]') }
     end
 
     context 'when Oracle Java SE 7 JRE' do
@@ -47,8 +47,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre7' }
 
       it { is_expected.to contain_archive('/tmp/jre-7u80-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').with_command('rpm --force -iv /tmp/jre-7u80-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').that_requires('Archive[/tmp/jre-7u80-linux-x64.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').with_command('rpm --force -iv /tmp/jre-7u80-linux-x64.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').that_requires('Archive[/tmp/jre-7u80-linux-x64.rpm]') }
     end
 
     context 'when select Oracle Java SE 8 JRE' do
@@ -56,8 +56,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre8' }
 
       it { is_expected.to contain_archive('/tmp/jre-8u131-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').with_command('rpm --force -iv /tmp/jre-8u131-linux-x64.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').that_requires('Archive[/tmp/jre-8u131-linux-x64.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').with_command('rpm --force -iv /tmp/jre-8u131-linux-x64.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').that_requires('Archive[/tmp/jre-8u131-linux-x64.rpm]') }
     end
 
     context 'when passing URL to url parameter' do
@@ -93,6 +93,34 @@ describe 'java::oracle', type: :define do
 
       it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-x64.rpm').with_source('http://download.oracle.com/otn-pub/java/jdk//8u131-b11/abcdef01234567890/jdk-8u131-linux-x64.rpm') }
     end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '8u131',
+          version_minor: 'b11',
+          java_se: 'jdk',
+          url_hash: 'abcdef01234567890',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::oracle {
+          'jdk8121':
+            ensure        => 'present',
+            version_major => '8u121',
+            version_minor => 'b11',
+            java_se       => 'jdk',
+            url_hash      => 'fiewojgfuiowfniweof',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
   end
 
   context 'when on CentOS 32-bit' do
@@ -103,8 +131,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk6' }
 
       it { is_expected.to contain_archive('/tmp/jdk-6u45-linux-i586-rpm.bin') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').with_command('sh /tmp/jdk-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').that_requires('Archive[/tmp/jdk-6u45-linux-i586-rpm.bin]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').with_command('sh /tmp/jdk-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jdk*.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').that_requires('Archive[/tmp/jdk-6u45-linux-i586-rpm.bin]') }
     end
 
     context 'when selecting Oracle Java SE 7 JDK on RedHat family, 32-bit' do
@@ -112,8 +140,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk7' }
 
       it { is_expected.to contain_archive('/tmp/jdk-7u80-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').with_command('rpm --force -iv /tmp/jdk-7u80-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').that_requires('Archive[/tmp/jdk-7u80-linux-i586.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').with_command('rpm --force -iv /tmp/jdk-7u80-linux-i586.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').that_requires('Archive[/tmp/jdk-7u80-linux-i586.rpm]') }
     end
 
     context 'when selecting Oracle Java SE 8 JDK on RedHat family, 32-bit' do
@@ -121,8 +149,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk8' }
 
       it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').with_command('rpm --force -iv /tmp/jdk-8u131-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').that_requires('Archive[/tmp/jdk-8u131-linux-i586.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').with_command('rpm --force -iv /tmp/jdk-8u131-linux-i586.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').that_requires('Archive[/tmp/jdk-8u131-linux-i586.rpm]') }
     end
 
     context 'when selecting Oracle Java SE 6 JRE on RedHat family, 32-bit' do
@@ -130,8 +158,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk6' }
 
       it { is_expected.to contain_archive('/tmp/jre-6u45-linux-i586-rpm.bin') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').with_command('sh /tmp/jre-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').that_requires('Archive[/tmp/jre-6u45-linux-i586-rpm.bin]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').with_command('sh /tmp/jre-6u45-linux-i586-rpm.bin -x; rpm --force -iv sun*.rpm; rpm --force -iv jre*.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').that_requires('Archive[/tmp/jre-6u45-linux-i586-rpm.bin]') }
     end
 
     context 'when select Oracle Java SE 7 JRE on RedHat family, 32-bit' do
@@ -139,8 +167,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk7' }
 
       it { is_expected.to contain_archive('/tmp/jre-7u80-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').with_command('rpm --force -iv /tmp/jre-7u80-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').that_requires('Archive[/tmp/jre-7u80-linux-i586.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').with_command('rpm --force -iv /tmp/jre-7u80-linux-i586.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').that_requires('Archive[/tmp/jre-7u80-linux-i586.rpm]') }
     end
 
     context 'when select Oracle Java SE 8 JRE on RedHat family, 32-bit' do
@@ -148,8 +176,36 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk8' }
 
       it { is_expected.to contain_archive('/tmp/jre-8u131-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').with_command('rpm --force -iv /tmp/jre-8u131-linux-i586.rpm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').that_requires('Archive[/tmp/jre-8u131-linux-i586.rpm]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').with_command('rpm --force -iv /tmp/jre-8u131-linux-i586.rpm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').that_requires('Archive[/tmp/jre-8u131-linux-i586.rpm]') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '8u131',
+          version_minor: 'b11',
+          java_se: 'jdk',
+          url_hash: 'abcdef01234567890',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::oracle {
+          'jdk8121':
+            ensure        => 'present',
+            version_major => '8u121',
+            version_minor => 'b11',
+            java_se       => 'jdk',
+            url_hash      => 'fiewojgfuiowfniweof',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
     end
   end
 
@@ -161,8 +217,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk6' }
 
       it { is_expected.to contain_archive('/tmp/jdk-6u45-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').with_command('tar -zxf /tmp/jdk-6u45-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').that_requires('Archive[/tmp/jdk-6u45-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').with_command('tar -zxf /tmp/jdk-6u45-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').that_requires('Archive[/tmp/jdk-6u45-linux-x64.tar.gz]') }
     end
 
     context 'with Oracle Java SE 7 JDK' do
@@ -170,8 +226,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk7' }
 
       it { is_expected.to contain_archive('/tmp/jdk-7u80-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').with_command('tar -zxf /tmp/jdk-7u80-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 7').that_requires('Archive[/tmp/jdk-7u80-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').with_command('tar -zxf /tmp/jdk-7u80-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 7 7u80 b15').that_requires('Archive[/tmp/jdk-7u80-linux-x64.tar.gz]') }
     end
 
     context 'with Oracle Java SE 8 JDK' do
@@ -179,8 +235,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk8' }
 
       it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').with_command('tar -zxf /tmp/jdk-8u131-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 8').that_requires('Archive[/tmp/jdk-8u131-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').with_command('tar -zxf /tmp/jdk-8u131-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 8 8u131 b11').that_requires('Archive[/tmp/jdk-8u131-linux-x64.tar.gz]') }
     end
 
     context 'with Oracle Java SE 6 JRE' do
@@ -188,8 +244,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre6' }
 
       it { is_expected.to contain_archive('/tmp/jre-6u45-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').with_command('tar -zxf /tmp/jre-6u45-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 6').that_requires('Archive[/tmp/jre-6u45-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').with_command('tar -zxf /tmp/jre-6u45-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 6 6u45 b06').that_requires('Archive[/tmp/jre-6u45-linux-x64.tar.gz]') }
     end
 
     context 'when Oracle Java SE 7 JRE' do
@@ -197,8 +253,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre7' }
 
       it { is_expected.to contain_archive('/tmp/jre-7u80-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').with_command('tar -zxf /tmp/jre-7u80-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 7').that_requires('Archive[/tmp/jre-7u80-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').with_command('tar -zxf /tmp/jre-7u80-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 7 7u80 b15').that_requires('Archive[/tmp/jre-7u80-linux-x64.tar.gz]') }
     end
 
     context 'when Oracle Java SE 8 JRE' do
@@ -206,8 +262,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jre8' }
 
       it { is_expected.to contain_archive('/tmp/jre-8u131-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').with_command('tar -zxf /tmp/jre-8u131-linux-x64.tar.gz -C /usr/lib/jvm') }
-      it { is_expected.to contain_exec('Install Oracle java_se jre 8').that_requires('Archive[/tmp/jre-8u131-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').with_command('tar -zxf /tmp/jre-8u131-linux-x64.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Oracle java_se jre 8 8u131 b11').that_requires('Archive[/tmp/jre-8u131-linux-x64.tar.gz]') }
     end
 
     context 'when passing URL to url parameter' do
@@ -215,6 +271,34 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk8' }
 
       it { is_expected.to contain_archive('/tmp/jdk-8u131-linux-x64.tar.gz') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '8u131',
+          version_minor: 'b11',
+          java_se: 'jdk',
+          url_hash: 'abcdef01234567890',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::oracle {
+          'jdk8121':
+            ensure        => 'present',
+            version_major => '8u121',
+            version_minor => 'b11',
+            java_se       => 'jdk',
+            url_hash      => 'fiewojgfuiowfniweof',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
     end
   end
   describe 'incompatible OSes' do


### PR DESCRIPTION
This adds support for installing the Oracle Cryptographic Extensions as requested in [MODULES-1681](https://tickets.puppetlabs.com/browse/MODULES-1681) and adds the appropriate tests.