### PR TITLE
(FM-7520) - Removing service pack extensions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,13 +65,8 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 SP1",
-        "11 SP2",
-        "11 SP3",
-        "11 SP4",
-        "12",
-        "12 SP1",
-        "12 SP2"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
We support SLES11 and SLES12. It is not necessary to state the SP
therefore removing the SPs.