### PR TITLE
(FM-7520) - Removing Solaris from the support matrix

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,13 +65,8 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 SP1",
-        "11 SP2",
-        "11 SP3",
-        "11 SP4",
-        "12",
-        "12 SP1",
-        "12 SP2"
+        "11",
+        "12"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -73,12 +73,6 @@
         "12 SP1",
         "12 SP2"
       ]
-    },
-    {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
This is a bug fix as Solaris has never worked on this module. Updating
to resolve the issue with our documentation.