### PR TITLE
Add ability to override basedir and package type for oracle java

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,6 +70,29 @@ java::oracle { 'jdk8' :
 }
 ```
 
+To install Oracle Java to a non-default basedir (defaults: /usr/lib/jvm for Debian; /usr/java for RedHat):
+```puppet
+java::oracle { 'jdk8' :
+  ensure  => 'present',
+  version_major => '8u101',
+  version_minor => 'b13',
+  java_se => 'jdk',
+  basedir => '/custom/java',
+}
+```
+
+To ensure that a custom basedir is a directory before Oracle Java is installed (note: manage separately for custom ownership or perms):
+```puppet
+java::oracle { 'jdk8' :
+  ensure  => 'present',
+  version_major => '8u101',
+  version_minor => 'b13',
+  java_se => 'jdk',
+  manage_basedir => true,
+  basedir => '/custom/java',
+}
+```
+
 ## Reference
 
 ### Classes

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -300,11 +300,7 @@ define java::oracle (
       $install_command = "rpm --force -iv ${destination}"
     }
     'tar.gz' : {
-      if $basedir {
-        $install_command = "tar -zxf ${destination} -C ${basedir}"
-      } else {
-        $install_command = "tar -zxf ${destination} -C /usr/lib/jvm"
-      }
+      $install_command = "tar -zxf ${destination} -C ${_basedir}"
     }
     default : {
       $install_command = "rpm -iv ${destination}"
@@ -327,10 +323,10 @@ define java::oracle (
         'Linux' : {
           case $facts['os']['family'] {
             'Debian' : {
-              ensure_resource('file', '/usr/lib/jvm', {
+              ensure_resource('file', $_basedir, {
                 ensure => directory,
               })
-              $install_requires = [Archive[$destination], File['/usr/lib/jvm']]
+              $install_requires = [Archive[$destination], File[$_basedir]]
             }
             default : {
               $install_requires = [Archive[$destination]]
@@ -338,7 +334,7 @@ define java::oracle (
           }
 
           if $manage_basedir {
-            ensure_resource('file', $basedir, {'ensure' => 'directory', 'before' => Exec["Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}"]})
+            ensure_resource('file', $_basedir, {'ensure' => 'directory', 'before' => Exec["Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}"]})
           }
 
           exec { "Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}" :

--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -54,6 +54,7 @@
 # [*package_type*]
 # Type of installation package for specified version of java_se. java_se 6 comes
 # in a few installation package flavors and we need to account for them.
+# Optional forced package types: rpm, rpmbin, tar.gz
 #
 # [*os*]
 # Oracle java_se OS type.
@@ -90,21 +91,32 @@
 # [*jce*]
 # Install Oracles Java Cryptographic Extensions into the JRE or JDK
 #
+# [*basedir*]
+# Directory under which the installation will occur. If not set, defaults to
+# /usr/lib/jvm for Debian and /usr/java for RedHat.
+#
+# [*manage_basedir*]
+# Whether to manage the basedir directory.  Defaults to false.
+# Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
+#
 # ### Author
 # mike@marseglia.org
 #
 define java::oracle (
-  $ensure        = 'present',
-  $version       = '8',
-  $version_major = undef,
-  $version_minor = undef,
-  $java_se       = 'jdk',
-  $oracle_url    = 'http://download.oracle.com/otn-pub/java/jdk/',
-  $proxy_server  = undef,
-  $proxy_type    = undef,
-  $url           = undef,
-  $url_hash      = undef,
-  $jce           = false,
+  $ensure         = 'present',
+  $version        = '8',
+  $version_major  = undef,
+  $version_minor  = undef,
+  $java_se        = 'jdk',
+  $oracle_url     = 'http://download.oracle.com/otn-pub/java/jdk/',
+  $proxy_server   = undef,
+  $proxy_type     = undef,
+  $url            = undef,
+  $url_hash       = undef,
+  $jce            = false,
+  $basedir        = undef,
+  $manage_basedir = false,
+  $package_type   = undef,
 ) {
 
   # archive module is used to download the java package
@@ -127,6 +139,7 @@ define java::oracle (
   # determine Oracle Java major and minor version, and installation path
   if $version_major and $version_minor {
 
+    $label         = $version_major
     $release_major = $version_major
     $release_minor = $version_minor
     $release_hash  = $url_hash
@@ -144,6 +157,7 @@ define java::oracle (
     }
   } else {
     # use default versions if no specific major and minor version parameters are provided
+    $label = $version
     case $version {
       '6' : {
         $release_major = '6u45'
@@ -178,21 +192,36 @@ define java::oracle (
       case $facts['os']['family'] {
         'RedHat', 'Amazon' : {
           # Oracle Java 6 comes in a special rpmbin format
-          if $version == '6' {
-            $package_type = 'rpmbin'
+          if $package_type {
+            $_package_type = $package_type
+          } elsif $version == '6' {
+            $_package_type = 'rpmbin'
           } else {
-            $package_type = 'rpm'
+            $_package_type = 'rpm'
           }
-          $creates_path = "/usr/java/${install_path}"
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/java'
+          }
         }
         'Debian' : {
-            $package_type = 'tar.gz'
-            $creates_path = "/usr/lib/jvm/${install_path}"
+          if $package_type {
+            $_package_type = $package_type
+          } else {
+            $_package_type = 'tar.gz'
+          }
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/lib/jvm'
+          }
         }
         default : {
           fail ("unsupported platform ${$facts['os']['name']}") }
       }
 
+      $creates_path = "${_basedir}/${install_path}"
       $os = 'linux'
       $destination_dir = '/tmp/'
     }
@@ -227,7 +256,7 @@ define java::oracle (
   # http://download.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-i586-rpm.bin
   # http://download.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-i586.bin
   # package name to download from Oracle's website
-  case $package_type {
+  case $_package_type {
     'bin' : {
       $package_name = "${java_se}-${release_major}-${os}-${arch}.bin"
     }
@@ -260,7 +289,7 @@ define java::oracle (
   $destination = "${destination_dir}${package_name}"
   notice ("Destination is ${destination}")
 
-  case $package_type {
+  case $_package_type {
     'bin' : {
       $install_command = "sh ${destination}"
     }
@@ -271,7 +300,11 @@ define java::oracle (
       $install_command = "rpm --force -iv ${destination}"
     }
     'tar.gz' : {
-      $install_command = "tar -zxf ${destination} -C /usr/lib/jvm"
+      if $basedir {
+        $install_command = "tar -zxf ${destination} -C ${basedir}"
+      } else {
+        $install_command = "tar -zxf ${destination} -C /usr/lib/jvm"
+      }
     }
     default : {
       $install_command = "rpm -iv ${destination}"
@@ -303,6 +336,11 @@ define java::oracle (
               $install_requires = [Archive[$destination]]
             }
           }
+
+          if $manage_basedir {
+            ensure_resource('file', $basedir, {'ensure' => 'directory', 'before' => Exec["Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}"]})
+          }
+
           exec { "Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
             command => $install_command,

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -158,8 +158,8 @@ describe 'java::oracle', type: :define do
       let(:title) { 'jdk6' }
 
       it { is_expected.to contain_archive('/tmp/jdk-6u45-linux-x64.tar.gz') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').with_command('tar -zxf /tmp/jdk-6u45-linux-x64.tar.gz -C /usr/java') }
-      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').that_requires('Archive[/tmp/jdk-6u45-linux-x64.tar.gz]') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').with_command('tar -zxf /tmp/jdk-6u45-linux-x64.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6 6u45 b06').that_requires('Archive[/tmp/jdk-6u45-linux-x64.tar.gz]') }
     end
     context 'when manage_basedir is set to true' do
       let(:params) do

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -144,6 +144,37 @@ describe 'java::oracle', type: :define do
         is_expected.to contain_archive('/tmp/jce-6.zip').with_extract_path('/usr/java/jdk1.6.0_99-amd64/jre/lib/security')
       end
     end
+
+    context 'when specifying package_type tar.gz and basedir' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '6',
+          java_se: 'jdk',
+          basedir: '/usr/java',
+          package_type: 'tar.gz',
+        }
+      end
+      let(:title) { 'jdk6' }
+
+      it { is_expected.to contain_archive('/tmp/jdk-6u45-linux-x64.tar.gz') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').with_command('tar -zxf /tmp/jdk-6u45-linux-x64.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install Oracle java_se jdk 6').that_requires('Archive[/tmp/jdk-6u45-linux-x64.tar.gz]') }
+    end
+    context 'when manage_basedir is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '6',
+          java_se: 'jdk',
+          basedir: '/usr/java',
+          manage_basedir: true,
+        }
+      end
+      let(:title) { 'jdk6' }
+
+      it { is_expected.to contain_file('/usr/java') }
+    end
   end
 
   context 'when on CentOS 32-bit' do


### PR DESCRIPTION
This is a resubmission of #298, because it looks like the original submitter lost interest.
In addition this fixes several small issues of the original submission:

- fix tests (the Exec was missing the full version information)
- use evaluated/os-dependent paths from `$_basedir` instead of hardcoded values

ping @david22swan 