### PR TITLE
MODULES-8699: Add option to manage symlink

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -99,6 +99,12 @@
 # Whether to manage the basedir directory.  Defaults to false.
 # Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
 #
+# [*manage_symlink*]
+# Whether to manage a symlink that points to the installation directory.  Defaults to false.
+#
+# [*symlink_name*]
+# The name for the optional symlink in the installation directory.
+#
 # ### Author
 # mike@marseglia.org
 #
@@ -117,6 +123,8 @@ define java::oracle (
   $basedir        = undef,
   $manage_basedir = false,
   $package_type   = undef,
+  $manage_symlink = false,
+  $symlink_name   = undef,
 ) {
 
   # archive module is used to download the java package
@@ -342,6 +350,14 @@ define java::oracle (
             command => $install_command,
             creates => $creates_path,
             require => $install_requires
+          }
+
+          if ($manage_symlink and $symlink_name) {
+            file { "${_basedir}/${symlink_name}":
+              ensure  => link,
+              target  => $creates_path,
+              require => Exec["Install Oracle java_se ${java_se} ${version} ${release_major} ${release_minor}"]
+            }
           }
 
           if ($jce and $jce_download != undef) {

--- a/spec/defines/oracle_spec.rb
+++ b/spec/defines/oracle_spec.rb
@@ -175,6 +175,21 @@ describe 'java::oracle', type: :define do
 
       it { is_expected.to contain_file('/usr/java') }
     end
+    context 'when manage_symlink is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '6',
+          java_se: 'jdk',
+          basedir: '/usr/java',
+          manage_symlink: true,
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk6' }
+
+      it { is_expected.to contain_file('/usr/java/java_home') }
+    end
   end
 
   context 'when on CentOS 32-bit' do


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-8699

This adds the capability to `java::oracle` to manage a symlink for this version, which will point to the Java installation directory. This is useful because it adds a static path that will never change, no matter which Java version is currently in use.

```
java::oracle { 'jdk8':
  basedir => '/mnt'
  java_se => 'jdk'
  version_major => '8u201'
  version_minor => 'b09'
  url_hash => '42970487e3af4f5aa5bca3f542482c60'
  package_type => 'tar.gz'
  manage_symlink => true
  symlink_name => 'java_home'
}

Info: Applying configuration version '1551101640'
Notice: /Stage[main]/Java::Oracle[jdk8]/Archive[/tmp/jdk-8u201-linux-x64.tar.gz]/ensure: download archive from [...]
Notice: /Stage[main]/Java::Oracle[jdk8]/Exec[Install Oracle java_se jdk 8 8u201 b09]/returns: executed successfully
Notice: /Stage[main]/Java::Oracle[jdk8]/File[/mnt/java_home]/ensure: created
```

This feature is also available in [puppet-jdk_oracle](https://github.com/tylerwalts/puppet-jdk_oracle), which is no longer maintained and suggests to use puppetlabs-java instead.

I've added a test for this too:

```
java::oracle
  with CentOS 64-bit
    ...
    when manage_symlink is set to true
      should contain File[/usr/java/java_home]
    ...
```