### PR TITLE
MODULES-8698: Fix $install_path on CentOS with tar.gz package type

### DIFF
--- a/manifests/oracle.pp
+++ b/manifests/oracle.pp
@@ -146,8 +146,9 @@ define java::oracle (
 
     if $release_major =~ /(\d+)u(\d+)/ {
       # Required for CentOS systems where Java8 update number is >= 171 to ensure
-      # the package is visible to Puppet
-      if $facts['os']['family'] == 'RedHat' and $2 >= '171' {
+      # the package is visible to Puppet. This is only true for installations that
+      # don't use the tar.gz package type.
+      if $facts['os']['family'] == 'RedHat' and $2 >= '171' and $package_type != 'tar.gz' {
         $install_path = "${java_se}1.${1}.0_${2}-amd64"
       } else {
         $install_path = "${java_se}1.${1}.0_${2}"


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-8698

When using `tar.gz` packages on CentOS, the architecture is not part of the name of the installation directory. In this case it's just "jdk1.8.0_201" instead of "jdk1.8.0_201-amd64".

This fix is required to avoid running Exec on _every_ Puppet run when using the following configuration:

```
java::oracle { 'jdk8':
  basedir => '/mnt'
  java_se => 'jdk'
  version_major => '8u201'
  version_minor => 'b09'
  url_hash => '42970487e3af4f5aa5bca3f542482c60'
  package_type => 'tar.gz'
}

Info: Applying configuration version '1551106786'
Notice: /Stage[main]/Java::Oracle[jdk8]/Exec[Install Oracle java_se jdk 8 8u201 b09]/returns: executed successfully
Notice: Applied catalog in 2.99 seconds
```