### PR TITLE
Add buster support, default to 11

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -170,7 +170,7 @@ class java::params {
             }
           }
         }
-        'bionic', 'cosmic', 'disco', 'eoan': {
+        'bionic', 'cosmic', 'disco', 'buster', 'eoan': {
           $java =  {
             'jdk' => {
               'package'          => 'openjdk-11-jdk',


### PR DESCRIPTION
Support buster as its release is imminent, and will default to JDK 11