### PR TITLE
Support AdoptOpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,56 @@ java::download { 'jdk8' :
 }
 ```
 
+The defined type `java::adopt` installs one or more versions of AdoptOpenJDK Java. `java::adopt` depends on [puppet/archive](https://github.com/voxpupuli/puppet-archive).
+
+```puppet
+java::adopt { 'jdk8' :
+  ensure  => 'present',
+  version => '8',
+  java => 'jdk',
+}
+
+java::adopt { 'jdk11' :
+  ensure  => 'present',
+  version => '11',
+  java => 'jdk',
+}
+```
+#TODO
+To install a specific release of a AdoptOpenJDK Java version, e.g. 8u202-b08, provide both parameters `version_major` and `version_minor` as follows:
+
+```puppet
+java::adopt { 'jdk8' :
+  ensure  => 'present',
+  version_major => '8u202',
+  version_minor => 'b08',
+  java => 'jdk',
+}
+```
+
+To install AdoptOpenJDK Java to a non-default basedir (defaults: /usr/lib/jvm for Debian; /usr/java for RedHat):
+```puppet
+java::adopt { 'jdk8' :
+  ensure  => 'present',
+  version_major => '8u202',
+  version_minor => 'b08',
+  java => 'jdk',
+  basedir => '/custom/java',
+}
+```
+
+To ensure that a custom basedir is a directory before AdoptOpenJDK Java is installed (note: manage separately for custom ownership or perms):
+```puppet
+java::adopt { 'jdk8' :
+  ensure  => 'present',
+  version_major => '8u202',
+  version_minor => 'b08',
+  java => 'jdk',
+  manage_basedir => true,
+  basedir => '/custom/java',
+}
+```
+
 ## Reference
 
 For information on the classes and types, see the [REFERENCE.md](https://github.com/puppetlabs/puppetlabs-java/blob/master/REFERENCE.md). For information on the facts, see below.
@@ -103,6 +153,13 @@ Oracle Java is supported on:
 * CentOS 6
 * CentOS 7
 * Red Hat Enterprise Linux (RHEL) 7
+
+AdoptOpenJDK Java is supported on:
+
+* CentOS
+* Red Hat Enterprise Linux (RHEL)
+* Amazon Linux
+* Debian
 
 ### Known issues
 

--- a/lib/facter/java_libjvm_path.rb
+++ b/lib/facter/java_libjvm_path.rb
@@ -17,20 +17,15 @@ Facter.add(:java_libjvm_path) do
     java_default_home = Facter.value(:java_default_home)
     java_major_version = Facter.value(:java_major_version)
     unless java_major_version.nil?
-      if java_major_version.to_i >= 11
-        java_libjvm_file = Dir.glob("#{java_default_home}/lib/**/libjvm.so")
-        if java_libjvm_file.nil? || java_libjvm_file.empty?
-          nil
-        else
-          File.dirname(java_libjvm_file[0])
-        end
+      java_libjvm_file = if java_major_version.to_i >= 11
+                           Dir.glob("#{java_default_home}/lib/**/libjvm.so")
+                         else
+                           Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")
+                         end
+      if java_libjvm_file.nil? || java_libjvm_file.empty?
+        nil
       else
-        java_libjvm_file = Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")
-        if java_libjvm_file.nil? || java_libjvm_file.empty?
-          nil
-        else
-          File.dirname(java_libjvm_file[0])
-        end
+        File.dirname(java_libjvm_file[0])
       end
     end
   end

--- a/lib/facter/java_libjvm_path.rb
+++ b/lib/facter/java_libjvm_path.rb
@@ -7,6 +7,7 @@
 #
 # Caveats:
 #   Needs to list files recursively. Returns the first match
+#   Needs working java_major_version fact
 #
 # Notes:
 #   None
@@ -14,13 +15,23 @@ Facter.add(:java_libjvm_path) do
   confine kernel: ['Linux', 'OpenBSD']
   setcode do
     java_default_home = Facter.value(:java_default_home)
-    if java_default_home
-      java_libjvm_file = Dir.glob("#{java_default_home}/**/lib/**/libjvm.so")
-    end
-    if java_libjvm_file.nil? || java_libjvm_file.empty?
-      nil
-    else
-      File.dirname(java_libjvm_file[0])
+    java_major_version = Facter.value(:java_major_version)
+    unless java_major_version.nil?
+      if java_major_version.to_i >= 11
+        java_libjvm_file = Dir.glob("#{java_default_home}/lib/**/libjvm.so")
+        if java_libjvm_file.nil? || java_libjvm_file.empty?
+          nil
+        else
+          File.dirname(java_libjvm_file[0])
+        end
+      else
+        java_libjvm_file = Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")
+        if java_libjvm_file.nil? || java_libjvm_file.empty?
+          nil
+        else
+          File.dirname(java_libjvm_file[0])
+        end
+      end
     end
   end
 end

--- a/lib/facter/java_major_version.rb
+++ b/lib/facter/java_major_version.rb
@@ -17,11 +17,11 @@ Facter.add(:java_major_version) do
   setcode do
     java_version = Facter.value(:java_version)
     unless java_version.nil?
-      if java_version.strip[0..1] == '1.'
-        java_major_version = java_version.strip.split('_')[0].split('.')[1]
-      else
-        java_major_version = java_version.strip.split('.')[0]
-      end
+      java_major_version = if java_version.strip[0..1] == '1.'
+                             java_version.strip.split('_')[0].split('.')[1]
+                           else
+                             java_version.strip.split('.')[0]
+                           end
     end
   end
   java_major_version

--- a/lib/facter/java_major_version.rb
+++ b/lib/facter/java_major_version.rb
@@ -17,13 +17,11 @@ Facter.add(:java_major_version) do
   setcode do
     java_version = Facter.value(:java_version)
     unless java_version.nil?
-      # First part > 1, use the first part as major version
-      java_version_first_number = java_version.strip.split('.')[0]
-      java_major_version = if java_version_first_number.to_i > 1
-                             java_version_first_number
-                           else
-                             java_version.strip.split('_')[0].split('.')[1]
-                           end
+      if java_version.strip[0..1] == '1.'
+        java_major_version = java_version.strip.split('_')[0].split('.')[1]
+      else
+        java_major_version = java_version.strip.split('.')[0]
+      end
     end
   end
   java_major_version

--- a/lib/facter/java_patch_level.rb
+++ b/lib/facter/java_patch_level.rb
@@ -3,7 +3,7 @@
 # Purpose: get Java's patch level
 #
 # Resolution:
-#   Uses java_version fact splits on the patch number (after _)
+#   Uses java_version fact splits on the patch number (after _ for 1.x and patch number for semver'ed javas)
 #
 # Caveats:
 #   none
@@ -15,13 +15,11 @@ Facter.add(:java_patch_level) do
   setcode do
     java_version = Facter.value(:java_version)
     unless java_version.nil?
-      # First part > 1, use . as seperator to get patch level
-      java_version_first_number = java_version.strip.split('.')[0]
-      java_patch_level = if java_version_first_number.to_i > 1
-                           java_version.strip.split('.')[2]
-                         else
-                           java_version.strip.split('_')[1]
-                         end
+      if java_version.strip[0..1] == '1.'
+        java_patch_level = java_version.strip.split('_')[1] unless java_version.nil?
+      else
+        java_patch_level = java_version.strip.split('.')[2] unless java_version.nil?
+      end
     end
   end
   java_patch_level

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -4,7 +4,7 @@
 #
 # Resolution:
 #   Tests for presence of java, returns nil if not present
-#   returns output of "java -version" and splits on \n + '"'
+#   returns output of "java -version" and splits on '"'
 #
 # Caveats:
 #   none
@@ -24,8 +24,7 @@ Facter.add(:java_version) do
     unless ['darwin'].include? Facter.value(:operatingsystem).downcase
       version = nil
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $LAST_MATCH_INFO[1] if %r{^.+ version \"(.+)\".*$} =~ line }
-
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = Regexp.last_match(1) if %r{^.+ version \"(.+)\"} =~ line }
       end
       version
     end
@@ -38,7 +37,7 @@ Facter.add(:java_version) do
   setcode do
     unless %r{Unable to find any JVMs matching version} =~ Facter::Util::Resolution.exec('/usr/libexec/java_home --failfast 2>&1')
       version = nil
-      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $LAST_MATCH_INFO[1] if %r{^.+ version \"(.+)\"$} =~ line }
+      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = Regexp.last_match(1) if %r{^.+ version \"(.+)\"} =~ line }
       version
     end
   end

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -172,6 +172,7 @@ define java::adopt (
 
   } else {
     $_version = $version
+    $_version_int = Numeric($_version)
     # use default versions if no specific major and minor version parameters are provided
     case $version {
       '8' : {
@@ -276,7 +277,7 @@ define java::adopt (
   # jre just replaces jdk with jre in the archive name, but not in the path name!
   # https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9.0.4%2B11/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz
 
-  if ( "${_version}" == '8' ) {
+  if ( $_version_int == 8 ) {
     $_release_minor_package_name = $release_minor
   } else {
     $_release_minor_package_name = "_${release_minor}"
@@ -293,7 +294,7 @@ define java::adopt (
 
   # naming convention changed after major version 8, setting variables to consider that
   # download_folder_prefix always begins with "jdk", even for jre! see comments for package_name above
-  if ( "${_version}" == '8' ) {
+  if ( $_version_int == 8 ) {
     $spacer = '-'
     $download_folder_prefix = 'jdk'
   } else {

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -1,0 +1,284 @@
+# Defined Type java::adopt
+#
+# Description
+# Installs OpenJDK Java built with AdoptOpenJDK with the Hotspot JVM.
+#
+# Install one or more versions of AdoptOpenJDK Java.
+#
+# Parameters
+# [*version*]
+# Version of Java to install, e.g. '7' or '8'. Default values for major and minor
+# versions will be used.
+#
+# [*version_major*]
+# Major version which should be installed, e.g. '8u101'. Must be used together with
+# version_minor.
+#
+# [*version_minor*]
+# Minor version which should be installed, e.g. 'b12'. Must be used together with
+# version_major.
+#
+# [*java_edition*]
+# Type of Java Edition to install, jdk or jre.
+#
+# [*ensure*]
+# Install or remove the package.
+#
+# [*proxy_server*]
+# Specify a proxy server, with port number if needed. ie: https://example.com:8080. (passed to archive)
+#
+# [*proxy_type*]
+# Proxy server type (none|http|https|ftp). (passed to archive)
+#
+# Variables
+# [*release_major*]
+# Major version release number for java_se. Used to construct download URL.
+#
+# [*release_minor*]
+# Minor version release number for java_se. Used to construct download URL.
+#
+# [*install_path*]
+# Base install path for specified version of java_se. Used to determine if java_se
+# has already been installed.
+#
+# [*package_type*]
+# Type of installation package for specified version of java_se. java_se 6 comes
+# in a few installation package flavors and we need to account for them.
+# Optional forced package types: rpm, rpmbin, tar.gz
+#
+# [*os*]
+# Oracle java_se OS type.
+#
+# [*destination*]
+# Destination directory to save java_se installer to.  Usually /tmp on Linux and
+# C:\TEMP on Windows.
+#
+# [*creates_path*]
+# Fully qualified path to java_se after it is installed. Used to determine if
+# java_se is already installed.
+#
+# [*arch*]
+# Oracle java_se architecture type.
+#
+# [*package_name*]
+# Name of the java_se installation package to download from Oracle's website.
+#
+# [*install_command*]
+# Installation command used to install Oracle java_se. Installation commands
+# differ by package_type. 'bin' types are installed via shell command. 'rpmbin'
+# types have the rpms extracted and then forcibly installed. 'rpm' types are
+# forcibly installed.
+#
+# [*basedir*]
+# Directory under which the installation will occur. If not set, defaults to
+# /usr/lib/jvm for Debian and /usr/java for RedHat.
+#
+# [*manage_basedir*]
+# Whether to manage the basedir directory.  Defaults to false.
+# Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
+#
+define java::adopt (
+  $ensure         = 'present',
+  $version        = '8',
+  $version_major  = undef,
+  $version_minor  = undef,
+  $java        = 'jdk',
+  $proxy_server   = undef,
+  $proxy_type     = undef,
+  $basedir        = undef,
+  $manage_basedir = false,
+  $package_type   = undef,
+) {
+
+  # archive module is used to download the java package
+  include ::archive
+
+  # validate java Standard Edition to download
+  if $java !~ /(jre|jdk)/ {
+    fail('java must be either jre or jdk.')
+  }
+
+  # determine AdoptOpenJDK Java major and minor version, and installation path
+  if $version_major and $version_minor {
+
+    $label         = $version_major
+    $release_major = $version_major
+    $release_minor = $version_minor
+
+    $install_path = "${java}${release_major}${release_minor}"
+
+  } else {
+    # use default versions if no specific major and minor version parameters are provided
+    $label = $version
+    case $version {
+      '8' : {
+        $release_major = '8u202'
+        $release_minor = 'b08'
+        $install_path = "${java}1.8.0_202"
+      }
+      '9' : {
+        $release_major = '9.0.4'
+        $release_minor = '_11'
+        $install_path = "${java}9.0.4_11"
+      }
+      '10' : {
+        $release_major = '10.0.2'
+        $release_minor = '+13'
+        $install_path = "${java}10.0.2_13"
+      }
+      '11' : {
+        $release_major = '11.0.2'
+        $release_minor = '_9'
+        $install_path = "${java}11.0.2_9"
+      }
+      default : {
+        $release_major = '8u202'
+        $release_minor = 'b08'
+        $install_path = "${java}1.8.0_192"
+      }
+    }
+  }
+
+  # determine package type (exe/tar/rpm), destination directory based on OS
+  case $facts['kernel'] {
+    'Linux' : {
+      case $facts['os']['family'] {
+        'RedHat', 'Amazon' : {
+          if $package_type {
+            $_package_type = $package_type
+          } else {
+            $_package_type = 'tar.gz'
+          }
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/java'
+          }
+        }
+        'Debian' : {
+          if $package_type {
+            $_package_type = $package_type
+          } else {
+            $_package_type = 'tar.gz'
+          }
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/lib/jvm'
+          }
+        }
+        default : {
+          fail ("unsupported platform ${$facts['os']['name']}") }
+      }
+
+      $creates_path = "${_basedir}/${install_path}"
+      $os = 'linux'
+      $destination_dir = '/tmp/'
+    }
+    default : {
+      fail ( "unsupported platform ${$facts['kernel']}" ) }
+  }
+
+  # set java architecture nomenclature
+  $os_architecture = $facts['os']['architecture'] ? {
+    undef => $facts['architecture'],
+    default => $facts['os']['architecture']
+  }
+
+  case $os_architecture {
+    'i386' : { $arch = 'x86-32' }
+    'x86_64' : { $arch = 'x64' }
+    'amd64' : { $arch = 'x64' }
+    default : {
+      fail ("unsupported platform ${$os_architecture}")
+    }
+  }
+
+  # following are based on this example:
+  # https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz
+  #
+  # or
+  #
+  # https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9.0.4%2B11/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+  # https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz
+  #
+  # package name to download from github
+  case $_package_type {
+    'tar.gz' : {
+      $package_name = "OpenJDK${version}U-${java}_${arch}_${os}_hotspot_${release_major}${release_minor}.tar.gz"
+    }
+    default : {
+      $package_name = "OpenJDK${version}U-${java}_${arch}_${os}_hotspot_${release_major}${release_minor}.tar.gz"
+    }
+  }
+
+  if ( $version == '8' ) {
+    $spacer = '-'
+    $release_minor_url = $release_minor
+  } else {
+    $spacer = '%2B'
+    $release_minor_url = $release_minor[1,-1]
+  }
+  $source = "https://github.com/AdoptOpenJDK/openjdk${version}-binaries/releases/download/jdk-${release_major}${spacer}${release_minor_url}/${package_name}"
+
+  # full path to the installer
+  $destination = "${destination_dir}${package_name}"
+  notice ("Destination is ${destination}")
+
+  case $_package_type {
+    'tar.gz' : {
+      $install_command = "tar -zxf ${destination} -C ${_basedir}"
+    }
+    default : {
+      $install_command = "tar -zxf ${destination} -C ${_basedir}"
+    }
+  }
+
+  case $ensure {
+    'present' : {
+      archive { $destination :
+        ensure       => present,
+        source       => $source,
+        extract_path => '/tmp',
+        cleanup      => false,
+        creates      => $creates_path,
+        proxy_server => $proxy_server,
+        proxy_type   => $proxy_type,
+      }
+      case $facts['kernel'] {
+        'Linux' : {
+          case $facts['os']['family'] {
+            'Debian' : {
+              ensure_resource('file', $_basedir, {
+                ensure => directory,
+              })
+              $install_requires = [Archive[$destination], File[$_basedir]]
+            }
+            default : {
+              $install_requires = [Archive[$destination]]
+            }
+          }
+
+          if $manage_basedir {
+            ensure_resource('file', $_basedir, {'ensure' => 'directory', 'before' => Exec["Install AdoptOpenJDK java ${java} ${version} ${release_major} ${release_minor}"]})
+          }
+
+          exec { "Install AdoptOpenJDK java ${java} ${version} ${release_major} ${release_minor}" :
+            path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+            command => $install_command,
+            creates => $creates_path,
+            require => $install_requires
+          }
+
+        }
+        default : {
+          fail ("unsupported platform ${$facts['kernel']}")
+        }
+      }
+    }
+    default : {
+      notice ("Action ${ensure} not supported.")
+    }
+  }
+
+}

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -134,7 +134,7 @@ define java::adopt (
       default : {
         $release_major = '8u202'
         $release_minor = 'b08'
-        $install_path = "${java}1.8.0_192"
+        $install_path = "${java}1.8.0_202"
       }
     }
   }
@@ -212,7 +212,7 @@ define java::adopt (
     }
   }
 
-  if ( $version == '8' ) {
+  if ( "${version}" == '8' ) {
     $spacer = '-'
     $download_folder_prefix = 'jdk'
     $release_minor_url = $release_minor

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -121,7 +121,7 @@ define java::adopt (
   $proxy_server   = undef,
   $proxy_type     = undef,
   $basedir        = undef,
-  $manage_basedir = false,
+  $manage_basedir = true,
   $package_type   = undef,
 ) {
 
@@ -342,7 +342,12 @@ define java::adopt (
           }
 
           if $manage_basedir {
-            ensure_resource('file', $_basedir, {'ensure' => 'directory', 'before' => Exec["Install AdoptOpenJDK java ${java} ${_version} ${release_major} ${release_minor}"]})
+            if (!defined(File[$_basedir])) {
+              file { $_basedir:
+                ensure => 'directory',
+                before => Exec["Install AdoptOpenJDK java ${java} ${_version} ${release_major} ${release_minor}"],
+              }
+            }
           }
 
           exec { "Install AdoptOpenJDK java ${java} ${_version} ${release_major} ${release_minor}" :

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -5,18 +5,20 @@
 #
 # Install one or more versions of AdoptOpenJDK Java.
 #
+# Currently only Linux RedHat, Amazon and Debian are supported.
+#
 # Parameters
 # [*version*]
-# Version of Java to install, e.g. '7' or '8'. Default values for major and minor
+# Version of Java to install, e.g. '8' or '9'. Default values for major and minor
 # versions will be used.
 #
 # [*version_major*]
-# Major version which should be installed, e.g. '8u101'. Must be used together with
+# Major version which should be installed, e.g. '8u101' or '9.0.4'. Must be used together with
 # version_minor.
 #
 # [*version_minor*]
-# Minor version which should be installed, e.g. 'b12'. Must be used together with
-# version_major.
+# Minor version which should be installed, e.g. 'b12' (for version = '8') or '11' (for version != '8').
+# Must be used together with version_major.
 #
 # [*java_edition*]
 # Type of Java Edition to install, jdk or jre.
@@ -30,45 +32,6 @@
 # [*proxy_type*]
 # Proxy server type (none|http|https|ftp). (passed to archive)
 #
-# Variables
-# [*release_major*]
-# Major version release number for java_se. Used to construct download URL.
-#
-# [*release_minor*]
-# Minor version release number for java_se. Used to construct download URL.
-#
-# [*install_path*]
-# Base install path for specified version of java_se. Used to determine if java_se
-# has already been installed.
-#
-# [*package_type*]
-# Type of installation package for specified version of java_se. java_se 6 comes
-# in a few installation package flavors and we need to account for them.
-# Optional forced package types: rpm, rpmbin, tar.gz
-#
-# [*os*]
-# Oracle java_se OS type.
-#
-# [*destination*]
-# Destination directory to save java_se installer to.  Usually /tmp on Linux and
-# C:\TEMP on Windows.
-#
-# [*creates_path*]
-# Fully qualified path to java_se after it is installed. Used to determine if
-# java_se is already installed.
-#
-# [*arch*]
-# Oracle java_se architecture type.
-#
-# [*package_name*]
-# Name of the java_se installation package to download from Oracle's website.
-#
-# [*install_command*]
-# Installation command used to install Oracle java_se. Installation commands
-# differ by package_type. 'bin' types are installed via shell command. 'rpmbin'
-# types have the rpms extracted and then forcibly installed. 'rpm' types are
-# forcibly installed.
-#
 # [*basedir*]
 # Directory under which the installation will occur. If not set, defaults to
 # /usr/lib/jvm for Debian and /usr/java for RedHat.
@@ -77,12 +40,84 @@
 # Whether to manage the basedir directory.  Defaults to false.
 # Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
 #
+# [*package_type*]
+# Type of installation package for specified version of java. java 6 comes
+# in a few installation package flavors and we need to account for them.
+# Optional forced package types: rpm, rpmbin, tar.gz
+#
+# Variables
+# [*release_major*]
+# Major version release number for java. Used to construct download URL.
+#
+# [*release_minor*]
+# Minor version release number for java. Used to construct download URL.
+#
+# [*install_path*]
+# Base install path for specified version of java. Used to determine if java
+# has already been installed.
+#
+# [*os*]
+# java OS type.
+#
+# [*destination*]
+# Destination directory to save java installer to.  Usually /tmp on Linux and
+# C:\TEMP on Windows.
+#
+# [*creates_path*]
+# Fully qualified path to java after it is installed. Used to determine if
+# java is already installed.
+#
+# [*arch*]
+# java architecture type.
+#
+# [*package_name*]
+# Name of the java installation package to download from github.
+#
+# [*install_command*]
+# Installation command used to install java. Installation commands
+# differ by package_type. 'bin' types are installed via shell command. 'rpmbin'
+# types have the rpms extracted and then forcibly installed. 'rpm' types are
+# forcibly installed.
+#
+# [*spacer*]
+# Spacer to be used in github download url. In major version 8 this is a simple dash
+# in later versions they use a crazy plus sign, which needs to be used in urlencoded
+# format
+#
+# [*download_folder_prefix*]
+# Download folder name begins differently depending on the release. After major release
+# 8, they have given it a dash. Be aware that even if you want to have a JRE, the folder
+# still begins with "jdk"
+#
+# [*release_minor_url*]
+# filled depending on major release. Until major release 8 the minor part needs to be given
+# with a 'b' for build, in later versions it is a underscore or a plus sign, which needs
+# to be stripped for the download url and is replaced with the given spaces (see above)
+#
+# [*_package_type*]
+# Helper variable which gets filled depending on parameter package_type
+#
+# [*_basedir*]
+# Helper variable which gets filled depending on parameter basedir
+#
+# [*_version*]
+# Helper variable which gets filled depending on parameter version
+#
+# [*_version_int*]
+# Helper variable which gets the value of $_version converted to integer
+#
+# [*_append_jre*]
+# Helper variable which gets filled with the string "-jre" if jre was selected to build the correct install path
+#
+# [*_release_minor_package_name*]
+# Helper variable which gets filled with the right minor string depending on the major version
+#
 define java::adopt (
   $ensure         = 'present',
   $version        = '8',
   $version_major  = undef,
   $version_minor  = undef,
-  $java        = 'jdk',
+  $java           = 'jdk',
   $proxy_server   = undef,
   $proxy_type     = undef,
   $basedir        = undef,
@@ -101,40 +136,75 @@ define java::adopt (
   # determine AdoptOpenJDK Java major and minor version, and installation path
   if $version_major and $version_minor {
 
-    $label         = $version_major
     $release_major = $version_major
     $release_minor = $version_minor
 
-    $install_path = "${java}${release_major}${release_minor}"
+    if ( $version_major[0] == '8' or $version_major[0] == '9' ) {
+      $_version = $version_major[0]
+    } else {
+      $_version = $version_major[0,2]
+    }
+
+    $_version_int = Numeric($_version)
+
+    if ( $java == 'jre' ) {
+      $_append_jre = '-jre'
+    } else {
+      $_append_jre = ''
+    }
+
+    # extracted folders look like this:
+    #  jdk8u202-b08
+    #  jdk-9.0.4+11
+    #  jdk-10.0.2+13
+    #  jdk-11.0.2+9
+    #  jdk-12.0.1+12
+    #  jdk8u202-b08-jre
+    #  jdk-9.0.4+11-jre
+    # hence we need to check for the major version and build the install path according to it
+    if ( $_version_int == 8 ) {
+      $install_path = "jdk${release_major}-${release_minor}${_append_jre}"
+    } elsif ( $_version_int > 8 ) {
+      $install_path = "jdk-${release_major}+${release_minor}${_append_jre}"
+    } else {
+      fail ("unsupported version ${_version}")
+    }
 
   } else {
+    $_version = $version
     # use default versions if no specific major and minor version parameters are provided
-    $label = $version
     case $version {
       '8' : {
         $release_major = '8u202'
         $release_minor = 'b08'
-        $install_path = "${java}1.8.0_202"
+        $install_path = "${java}8u202-b08"
       }
       '9' : {
         $release_major = '9.0.4'
-        $release_minor = '_11'
-        $install_path = "${java}9.0.4_11"
+        $release_minor = '11'
+        $install_path = "${java}-9.0.4+11"
       }
+      # minor release is given with +<number>, however package etc. works with underscore, so we use underscore here
       '10' : {
         $release_major = '10.0.2'
-        $release_minor = '+13'
-        $install_path = "${java}10.0.2_13"
+        $release_minor = '13'
+        $install_path = "${java}-10.0.2+13"
       }
       '11' : {
         $release_major = '11.0.2'
-        $release_minor = '_9'
-        $install_path = "${java}11.0.2_9"
+        $release_minor = '9'
+        $install_path = "${java}-11.0.2+9"
+      }
+      # minor release is given with +<number>, however package etc. works with underscore, so we use underscore here
+      '12' : {
+        $release_major = '12.0.1'
+        $release_minor = '12'
+        $install_path = "${java}-12.0.1+12"
       }
       default : {
         $release_major = '8u202'
         $release_minor = 'b08'
-        $install_path = "${java}1.8.0_202"
+        $install_path = "${java}8u202-b08"
       }
     }
   }
@@ -194,34 +264,43 @@ define java::adopt (
     }
   }
 
-  # following are based on this example:
+  # package name and path for download from github
+  #
+  # following are build based on this real life example full URLs:
+  #
   # https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz
-  #
-  # or
-  #
   # https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9.0.4%2B11/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz
+  # https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz
   # https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz
-  #
-  # package name to download from github
+  # https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz
+  # jre just replaces jdk with jre in the archive name, but not in the path name!
+  # https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9.0.4%2B11/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz
+
+  if ( "${_version}" == '8' ) {
+    $_release_minor_package_name = $release_minor
+  } else {
+    $_release_minor_package_name = "_${release_minor}"
+  }
+
   case $_package_type {
-    'tar.gz' : {
-      $package_name = "OpenJDK${version}U-${java}_${arch}_${os}_hotspot_${release_major}${release_minor}.tar.gz"
+    'tar.gz': {
+      $package_name = "OpenJDK${_version}U-${java}_${arch}_${os}_hotspot_${release_major}${_release_minor_package_name}.tar.gz"
     }
-    default : {
-      $package_name = "OpenJDK${version}U-${java}_${arch}_${os}_hotspot_${release_major}${release_minor}.tar.gz"
+    default: {
+      $package_name = "OpenJDK${_version}U-${java}_${arch}_${os}_hotspot_${release_major}${_release_minor_package_name}.tar.gz"
     }
   }
 
-  if ( "${version}" == '8' ) {
+  # naming convention changed after major version 8, setting variables to consider that
+  # download_folder_prefix always begins with "jdk", even for jre! see comments for package_name above
+  if ( "${_version}" == '8' ) {
     $spacer = '-'
     $download_folder_prefix = 'jdk'
-    $release_minor_url = $release_minor
   } else {
     $spacer = '%2B'
     $download_folder_prefix = 'jdk-'
-    $release_minor_url = $release_minor[1,-1]
   }
-  $source = "https://github.com/AdoptOpenJDK/openjdk${version}-binaries/releases/download/${download_folder_prefix}${release_major}${spacer}${release_minor_url}/${package_name}"
+  $source = "https://github.com/AdoptOpenJDK/openjdk${_version}-binaries/releases/download/${download_folder_prefix}${release_major}${spacer}${release_minor}/${package_name}"
 
   # full path to the installer
   $destination = "${destination_dir}${package_name}"
@@ -262,10 +341,10 @@ define java::adopt (
           }
 
           if $manage_basedir {
-            ensure_resource('file', $_basedir, {'ensure' => 'directory', 'before' => Exec["Install AdoptOpenJDK java ${java} ${version} ${release_major} ${release_minor}"]})
+            ensure_resource('file', $_basedir, {'ensure' => 'directory', 'before' => Exec["Install AdoptOpenJDK java ${java} ${_version} ${release_major} ${release_minor}"]})
           }
 
-          exec { "Install AdoptOpenJDK java ${java} ${version} ${release_major} ${release_minor}" :
+          exec { "Install AdoptOpenJDK java ${java} ${_version} ${release_major} ${release_minor}" :
             path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
             command => $install_command,
             creates => $creates_path,

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -214,12 +214,14 @@ define java::adopt (
 
   if ( $version == '8' ) {
     $spacer = '-'
+    $download_folder_prefix = 'jdk'
     $release_minor_url = $release_minor
   } else {
     $spacer = '%2B'
+    $download_folder_prefix = 'jdk-'
     $release_minor_url = $release_minor[1,-1]
   }
-  $source = "https://github.com/AdoptOpenJDK/openjdk${version}-binaries/releases/download/jdk-${release_major}${spacer}${release_minor_url}/${package_name}"
+  $source = "https://github.com/AdoptOpenJDK/openjdk${version}-binaries/releases/download/${download_folder_prefix}${release_major}${spacer}${release_minor_url}/${package_name}"
 
   # full path to the installer
   $destination = "${destination_dir}${package_name}"

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper_acceptance'
+require 'pry'
 
 java_class_jre = "class { 'java':\n"\
                  "  distribution => 'jre',\n"\
@@ -41,7 +42,6 @@ bogus_alternative = "class { 'java':\n"\
                     "  java_alternative_path => '/whatever',\n"\
                     '}'
 
-context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
 # Oracle installs are disabled by default, because the links to valid oracle installations
 # change often. Look the parameters up from the Oracle download URLs at https://java.oracle.com and
 # enable the tests:
@@ -138,7 +138,7 @@ install_adopt_jdk_jre = <<EOL
   }
 EOL
 
-context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
   it 'installs jre' do
     idempotent_apply(java_class_jre)
   end
@@ -176,17 +176,17 @@ context 'with failure cases' do
   end
 end
 
-context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
   let(:install_path) do
-    (fact('osfamily') == 'RedHat') ? '/usr/java' : '/usr/lib/jvm'
+    (os[:family] == 'redhat') ? '/usr/java' : '/usr/lib/jvm'
   end
 
   let(:version_suffix) do
-    (fact('osfamily') == 'RedHat') ? '-amd64' : ''
+    (os[:family] == 'redhat') ? '-amd64' : ''
   end
 
   it 'installs oracle jdk and jre' do
-    idempotent_apply(default, install_oracle_jdk_jre)
+    idempotent_apply(install_oracle_jdk_jre)
     jdk_result = shell("test ! -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
     jre_result = shell("test ! -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
     expect(jdk_result.exit_code).to eq(0)
@@ -194,28 +194,28 @@ context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.includ
   end
 
   it 'installs oracle jdk with jce' do
-    idempotent_apply(default, install_oracle_jdk_jce)
+    idempotent_apply(install_oracle_jdk_jce)
     result = shell("test -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
     expect(result.exit_code).to eq(0)
   end
 
   it 'installs oracle jre with jce' do
-    idempotent_apply(default, install_oracle_jre_jce)
+    idempotent_apply(install_oracle_jre_jce)
     result = shell("test -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
     expect(result.exit_code).to eq(0)
   end
 end
 
-context 'java::adopt', if: adopt_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+context 'java::adopt', if: adopt_enabled, unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
   let(:install_path) do
-    (fact('osfamily') == 'RedHat') ? '/usr/java' : '/usr/lib/jvm'
+    (os[:family] == 'redhat') ? '/usr/java' : '/usr/lib/jvm'
   end
 
   let(:version_suffix) do
-    (fact('osfamily') == 'RedHat') ? '-amd64' : ''
+    (os[:family] == 'redhat') ? '-amd64' : ''
   end
 
   it 'installs adopt jdk and jre' do
-    idempotent_apply(default, install_adopt_jdk_jre)
+    idempotent_apply(install_adopt_jdk_jre)
   end
 end

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -42,6 +42,103 @@ bogus_alternative = "class { 'java':\n"\
                     '}'
 
 context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
+# Oracle installs are disabled by default, because the links to valid oracle installations
+# change often. Look the parameters up from the Oracle download URLs at https://java.oracle.com and
+# enable the tests:
+
+oracle_enabled = false
+oracle_version_major = '8'
+oracle_version_minor = '201'
+oracle_version_build = '09'
+oracle_hash = '42970487e3af4f5aa5bca3f542482c60'
+
+install_oracle_jdk_jre = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jre',
+  }
+  java::oracle {
+    'test_oracle_jdk':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jdk',
+  }
+EOL
+
+install_oracle_jre_jce = <<EOL
+  java::oracle {
+    'test_oracle_jre':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jre',
+      jce           => true,
+  }
+
+EOL
+
+install_oracle_jdk_jce = <<EOL
+  java::oracle {
+    'test_oracle_jdk':
+      version       => '#{oracle_version_major}',
+      version_major => '#{oracle_version_major}u#{oracle_version_minor}',
+      version_minor => 'b#{oracle_version_build}',
+      url_hash      => '#{oracle_hash}',
+      java_se       => 'jdk',
+      jce           => true,
+  }
+EOL
+
+# AdoptOpenJDK URLs are quite generic, so tests are enabled by default
+# We need to test version 8 and >8 (here we use 9), because namings are different after version 8
+
+adopt_enabled = true
+adopt_version8_major = '8'
+adopt_version8_minor = '202'
+adopt_version8_build = '08'
+adopt_version9_major = '9'
+adopt_version9_full = '9.0.4'
+adopt_version9_build = '11'
+
+install_adopt_jdk_jre = <<EOL
+  java::adopt {
+    'test_adopt_jre_version8':
+      version       => '#{adopt_version8_major}',
+      version_major => '#{adopt_version8_major}u#{adopt_version8_minor}',
+      version_minor => 'b#{adopt_version8_build}',
+      java          => 'jre',
+  }
+  java::adopt {
+    'test_adopt_jdk_version8':
+      version       => '#{adopt_version8_major}',
+      version_major => '#{adopt_version8_major}u#{adopt_version8_minor}',
+      version_minor => 'b#{adopt_version8_build}',
+      java          => 'jdk',
+  }
+  java::adopt {
+    'test_adopt_jre_version9':
+      version       => '#{adopt_version9_major}',
+      version_major => '#{adopt_version9_full}',
+      version_minor => '#{adopt_version9_build}',
+      java          => 'jre',
+  }
+  java::adopt {
+    'test_adopt_jdk_version9':
+      version       => '#{adopt_version9_major}',
+      version_major => '#{adopt_version9_full}',
+      version_minor => '#{adopt_version9_build}',
+      java          => 'jdk',
+  }
+EOL
+
+context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'installs jre' do
     idempotent_apply(java_class_jre)
   end
@@ -76,5 +173,49 @@ context 'with failure cases' do
     else
       apply_manifest(bogus_alternative, expect_failures: true)
     end
+  end
+end
+
+context 'java::oracle', if: oracle_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  let(:install_path) do
+    (fact('osfamily') == 'RedHat') ? '/usr/java' : '/usr/lib/jvm'
+  end
+
+  let(:version_suffix) do
+    (fact('osfamily') == 'RedHat') ? '-amd64' : ''
+  end
+
+  it 'installs oracle jdk and jre' do
+    idempotent_apply(default, install_oracle_jdk_jre)
+    jdk_result = shell("test ! -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
+    jre_result = shell("test ! -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
+    expect(jdk_result.exit_code).to eq(0)
+    expect(jre_result.exit_code).to eq(0)
+  end
+
+  it 'installs oracle jdk with jce' do
+    idempotent_apply(default, install_oracle_jdk_jce)
+    result = shell("test -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
+  end
+
+  it 'installs oracle jre with jce' do
+    idempotent_apply(default, install_oracle_jre_jce)
+    result = shell("test -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
+    expect(result.exit_code).to eq(0)
+  end
+end
+
+context 'java::adopt', if: adopt_enabled, unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  let(:install_path) do
+    (fact('osfamily') == 'RedHat') ? '/usr/java' : '/usr/lib/jvm'
+  end
+
+  let(:version_suffix) do
+    (fact('osfamily') == 'RedHat') ? '-amd64' : ''
+  end
+
+  it 'installs adopt jdk and jre' do
+    idempotent_apply(default, install_adopt_jdk_jre)
   end
 end

--- a/spec/defines/adopt_spec.rb
+++ b/spec/defines/adopt_spec.rb
@@ -49,7 +49,6 @@ describe 'java::adopt', type: :define do
       it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 12 12.0.1 12').that_requires('Archive[/tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz]') }
     end
 
-
     context 'when AdoptOpenJDK Java 8 JRE' do
       let(:params) { { ensure: 'present', version: '8', java: 'jre' } }
       let(:title) { 'jre8' }
@@ -249,10 +248,10 @@ describe 'java::adopt', type: :define do
     context 'when installing multiple versions' do
       let(:params) do
         {
-            ensure: 'present',
-            version_major: '8u202',
-            version_minor: 'b08',
-            java: 'jdk',
+          ensure: 'present',
+          version_major: '8u202',
+          version_minor: 'b08',
+          java: 'jdk',
         }
       end
       let(:title) { 'jdk8' }
@@ -271,7 +270,6 @@ describe 'java::adopt', type: :define do
 
       it { is_expected.to compile }
     end
-
   end
   describe 'incompatible OSes' do
     [

--- a/spec/defines/adopt_spec.rb
+++ b/spec/defines/adopt_spec.rb
@@ -1,0 +1,337 @@
+require 'spec_helper'
+
+describe 'java::adopt', type: :define do
+  context 'with CentOS 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'RedHat', architecture: 'x86_64', name: 'CentOS', release: { full: '6.0' } } } }
+
+    context 'when AdoptOpenJDK Java 8 JDK' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jdk' } }
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').with_command('tar -zxf /tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').that_requires('Archive[/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 9 JDK' do
+      let(:params) { { ensure: 'present', version: '9', java: 'jdk' } }
+      let(:title) { 'jdk9' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 9 9.0.4 11').with_command('tar -zxf /tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 9 9.0.4 11').that_requires('Archive[/tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 10 JDK' do
+      let(:params) { { ensure: 'present', version: '10', java: 'jdk' } }
+      let(:title) { 'jdk10' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 10 10.0.2 13').with_command('tar -zxf /tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 10 10.0.2 13').that_requires('Archive[/tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 11 JDK' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jdk' } }
+      let(:title) { 'jdk11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 11 11.0.2 9').with_command('tar -zxf /tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 11 11.0.2 9').that_requires('Archive[/tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 12 JDK' do
+      let(:params) { { ensure: 'present', version: '12', java: 'jdk' } }
+      let(:title) { 'jdk12' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 12 12.0.1 12').with_command('tar -zxf /tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 12 12.0.1 12').that_requires('Archive[/tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz]') }
+    end
+
+
+    context 'when AdoptOpenJDK Java 8 JRE' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jre' } }
+      let(:title) { 'jre8' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 8 8u202 b08').with_command('tar -zxf /tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 8 8u202 b08').that_requires('Archive[/tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 9 JRE' do
+      let(:params) { { ensure: 'present', version: '9', java: 'jre' } }
+      let(:title) { 'jre9' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 9 9.0.4 11').with_command('tar -zxf /tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 9 9.0.4 11').that_requires('Archive[/tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 10 JRE' do
+      let(:params) { { ensure: 'present', version: '10', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 10 10.0.2 13').with_command('tar -zxf /tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 10 10.0.2 13').that_requires('Archive[/tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 11 JRE' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 11 11.0.2 9').with_command('tar -zxf /tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 11 11.0.2 9').that_requires('Archive[/tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 12 JRE' do
+      let(:params) { { ensure: 'present', version: '12', java: 'jre' } }
+      let(:title) { 'jre12' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 12 12.0.1 12').with_command('tar -zxf /tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 12 12.0.1 12').that_requires('Archive[/tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz]') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '8u202',
+          version_minor: 'b08',
+          java: 'jdk',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::adopt {
+          'jdk8172':
+            ensure        => 'present',
+            version_major => '8u172',
+            version_minor => 'b11',
+            java          => 'jdk',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+
+    context 'when specifying package_type tar.gz and basedir' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '8',
+          java: 'jdk',
+          basedir: '/usr/java',
+          package_type: 'tar.gz',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').with_command('tar -zxf /tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').that_requires('Archive[/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz]') }
+    end
+    context 'when manage_basedir is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '8',
+          java: 'jdk',
+          basedir: '/usr/java',
+          manage_basedir: true,
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_file('/usr/java') }
+    end
+  end
+
+  context 'with Ubuntu 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'Debian', architecture: 'amd64', name: 'Ubuntu', release: { full: '16.04' } } } }
+
+    context 'when AdoptOpenJDK Java 8 JDK' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jdk' } }
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').with_command('tar -zxf /tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 8 8u202 b08').that_requires('Archive[/tmp/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 9 JDK' do
+      let(:params) { { ensure: 'present', version: '9', java: 'jdk' } }
+      let(:title) { 'jdk9' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 9 9.0.4 11').with_command('tar -zxf /tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 9 9.0.4 11').that_requires('Archive[/tmp/OpenJDK9U-jdk_x64_linux_hotspot_9.0.4_11.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 10 JDK' do
+      let(:params) { { ensure: 'present', version: '10', java: 'jdk' } }
+      let(:title) { 'jdk10' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 10 10.0.2 13').with_command('tar -zxf /tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 10 10.0.2 13').that_requires('Archive[/tmp/OpenJDK10U-jdk_x64_linux_hotspot_10.0.2_13.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 11 JDK' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jdk' } }
+      let(:title) { 'jdk11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 11 11.0.2 9').with_command('tar -zxf /tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 11 11.0.2 9').that_requires('Archive[/tmp/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 12 JDK' do
+      let(:params) { { ensure: 'present', version: '12', java: 'jdk' } }
+      let(:title) { 'jdk12' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 12 12.0.1 12').with_command('tar -zxf /tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jdk 12 12.0.1 12').that_requires('Archive[/tmp/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 8 JRE' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jre' } }
+      let(:title) { 'jre8' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 8 8u202 b08').with_command('tar -zxf /tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 8 8u202 b08').that_requires('Archive[/tmp/OpenJDK8U-jre_x64_linux_hotspot_8u202b08.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 9 JRE' do
+      let(:params) { { ensure: 'present', version: '9', java: 'jre' } }
+      let(:title) { 'jre9' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 9 9.0.4 11').with_command('tar -zxf /tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 9 9.0.4 11').that_requires('Archive[/tmp/OpenJDK9U-jre_x64_linux_hotspot_9.0.4_11.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 10 JRE' do
+      let(:params) { { ensure: 'present', version: '10', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 10 10.0.2 13').with_command('tar -zxf /tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 10 10.0.2 13').that_requires('Archive[/tmp/OpenJDK10U-jre_x64_linux_hotspot_10.0.2_13.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 11 JRE' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 11 11.0.2 9').with_command('tar -zxf /tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 11 11.0.2 9').that_requires('Archive[/tmp/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz]') }
+    end
+
+    context 'when AdoptOpenJDK Java 12 JRE' do
+      let(:params) { { ensure: 'present', version: '12', java: 'jre' } }
+      let(:title) { 'jre12' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 12 12.0.1 12').with_command('tar -zxf /tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install AdoptOpenJDK java jre 12 12.0.1 12').that_requires('Archive[/tmp/OpenJDK12U-jre_x64_linux_hotspot_12.0.1_12.tar.gz]') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+            ensure: 'present',
+            version_major: '8u202',
+            version_minor: 'b08',
+            java: 'jdk',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::adopt {
+          'jdk8172':
+            ensure        => 'present',
+            version_major => '8u172',
+            version_minor => 'b11',
+            java          => 'jdk',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+
+  end
+  describe 'incompatible OSes' do
+    [
+      {
+        kernel: 'Windows',
+        os: {
+          family: 'Windows',
+          name: 'Windows',
+          release: {
+            full: '8.1',
+          },
+        },
+      },
+      {
+        kernel: 'Darwin',
+        os: {
+          family: 'Darwin',
+          name: 'Darwin',
+          release: {
+            full: '13.3.0',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '7100-02-00-000',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '6100-07-04-1216',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '5300-12-01-1016',
+          },
+        },
+      },
+    ].each do |facts|
+      let(:facts) { facts }
+      let(:title) { 'jdk' }
+
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
+        expect { catalogue }.to raise_error Puppet::Error, %r{unsupported platform}
+      end
+    end
+  end
+end

--- a/spec/unit/facter/java_libjvm_path_spec.rb
+++ b/spec/unit/facter/java_libjvm_path_spec.rb
@@ -5,20 +5,21 @@ describe 'java_libjvm_path' do
 
   before(:each) do
     Facter.clear
-    allow(Facter.fact(:kernel)).to receive(:value).once.and_return('Linux')
-    allow(Facter.fact(:java_default_home)).to receive(:value).once.and_return(java_default_home)
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+    allow(Facter.fact(:java_default_home)).to receive(:value).and_return(java_default_home)
   end
 
   context 'when libjvm exists' do
     it do
-      allow(Dir).to receive(:glob).with("#{java_default_home}/**/lib/**/libjvm.so").and_return(['/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so'])
+      allow(Facter.fact(:java_major_version)).to receive(:value).and_return(8)
+      allow(Dir).to receive(:glob).with("#{java_default_home}/jre/lib/**/libjvm.so").and_return(['/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so'])
       expect(Facter.value(:java_libjvm_path)).to eql '/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server'
     end
   end
 
   context 'when libjvm does not exist' do
     it do
-      allow(Dir).to receive(:glob).with("#{java_default_home}/**/lib/**/libjvm.so").and_return([])
+      allow(Dir).to receive(:glob).with("#{java_default_home}/lib/**/libjvm.so").and_return([])
       expect(Facter.value(:java_libjvm_path)).to be nil
     end
   end

--- a/spec/unit/facter/java_major_version_spec.rb
+++ b/spec/unit/facter/java_major_version_spec.rb
@@ -16,7 +16,7 @@ describe 'java_major_version' do
 
   context 'when java not present, returns nil' do
     before :each do
-      allow(Facter.fact(:java_version)).to receive(:value).and_return('nil')
+      allow(Facter.fact(:java_version)).to receive(:value).and_return(nil)
     end
     it do
       expect(Facter.fact(:java_major_version).value).to be_nil


### PR DESCRIPTION
Since Oracle changed their licensing policies, alternatives are becoming more and more important.

The OpenJDK packages bundled with the different Linux operating systems are sometimes enough, but often you need specific versions, which are not available in the package management of the OS. Here AdoptOpenJDK comes to the stage, providing binary distributions in different archive formats, which are ready to use after simple extracting.

With this PR i provide code very similar to the oracle define for AdoptOpenJDK. I also changed documentation and added spec and acceptance tests, which run without errors.

Be aware that path and file naming in the AdoptOpenJDK world is somewhat crazy and i needed to implement a few tricks and tweaks to cover that.

The only thing i did not cover from the contributing guidelines were the commit messages, but maybe you can fix that by doing a squash merge combined with a good commit message.

If you have improvements or concerns, let me know. Otherwise we would be happy with a merge, because we need that feature in our environment (currently we use my github fork). Thanks!