### PR TITLE
Add support for java 11, the default in debian buster 10

### DIFF
--- a/lib/facter/java_libjvm_path.rb
+++ b/lib/facter/java_libjvm_path.rb
@@ -14,7 +14,7 @@ Facter.add(:java_libjvm_path) do
   confine kernel: ['Linux', 'OpenBSD']
   setcode do
     java_default_home = Facter.value(:java_default_home)
-    java_libjvm_file = Dir.glob("#{java_default_home}/jre/lib/**/libjvm.so")
+    java_libjvm_file = Dir.glob("#{java_default_home}/**/lib/**/libjvm.so")
     if java_libjvm_file.nil? || java_libjvm_file.empty?
       nil
     else

--- a/lib/facter/java_major_version.rb
+++ b/lib/facter/java_major_version.rb
@@ -16,7 +16,15 @@ Facter.add(:java_major_version) do
   java_major_version = nil
   setcode do
     java_version = Facter.value(:java_version)
-    java_major_version = java_version.strip.split('_')[0].split('.')[1] unless java_version.nil?
+    unless java_version.nil?
+      # First part > 1, use the first part as major version
+      java_version_test = java_version.strip.split('.')[0]
+      if java_version_test.to_i > 1
+        java_major_version = java_version_test
+      else
+        java_major_version = java_version.strip.split('_')[0].split('.')[1]
+      end
+    end
   end
   java_major_version
 end

--- a/lib/facter/java_patch_level.rb
+++ b/lib/facter/java_patch_level.rb
@@ -14,7 +14,16 @@ Facter.add(:java_patch_level) do
   java_patch_level = nil
   setcode do
     java_version = Facter.value(:java_version)
-    java_patch_level = java_version.strip.split('_')[1] unless java_version.nil?
+    unless java_version.nil?
+      # First part > 1, use . as seperator to get patch level
+      java_version_test = java_version.strip.split('.')[0]
+      if java_version_test.to_i > 1
+        java_patch_level = java_version.strip.split('.')[2]
+      else
+        java_patch_level = java_version.strip.split('_')[1]
+      end
+    end
+
   end
   java_patch_level
 end

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -24,7 +24,8 @@ Facter.add(:java_version) do
     unless ['darwin'].include? Facter.value(:operatingsystem).downcase
       version = nil
       if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $LAST_MATCH_INFO[1] if %r{^.+ version \"(.+)\"$} =~ line }
+        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = $LAST_MATCH_INFO[1] if %r{^.+ version \"(.+)\".*$} =~ line }
+
       end
       version
     end

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -53,6 +53,22 @@ describe 'java', type: :class do
     it { is_expected.not_to contain_exec('update-java-alternatives') }
   end
 
+  context 'when select jdk for Debian Buster (10.0)' do
+    let(:facts) { { osfamily: 'Debian', operatingsystem: 'Debian', lsbdistcodename: 'buster', operatingsystemmajrelease: '10', architecture: 'amd64' } }
+    let(:params) { { 'distribution' => 'jdk' } }
+
+    it { is_expected.to contain_package('java').with_name('openjdk-11-jdk') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64/') }
+  end
+
+  context 'when select jre for Debian Buster (10.0)' do
+    let(:facts) { { osfamily: 'Debian', operatingsystem: 'Debian', lsbdistcodename: 'buster', operatingsystemmajrelease: '10', architecture: 'amd64' } }
+    let(:params) { { 'distribution' => 'jre' } }
+
+    it { is_expected.to contain_package('java').with_name('openjdk-11-jre-headless') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64/') }
+  end
+
   context 'when select jdk for Ubuntu Trusty (14.04)' do
     let(:facts) { { osfamily: 'Debian', operatingsystem: 'Ubuntu', lsbdistcodename: 'trusty', operatingsystemmajrelease: '14.04', architecture: 'amd64' } }
     let(:params) { { 'distribution' => 'jdk' } }

--- a/spec/defines/download_spec.rb
+++ b/spec/defines/download_spec.rb
@@ -67,6 +67,18 @@ describe 'java::download', type: :define do
       it { is_expected.to contain_archive('/tmp/jdk-8u201-linux-x64.tar.gz') }
     end
   end
+
+  context 'with Debian 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'Debian', architecture: 'amd64', name: 'Debian', release: { full: '10.0' } } } }
+
+    context 'when passing URL to url parameter' do
+      let(:params) { { ensure: 'present', version_major: '8u201', version_minor: 'b09', java_se: 'jdk', url: $url } }
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/jdk-8u201-linux-x64.tar.gz') }
+    end
+  end
+
   describe 'incompatible OSes' do
     [
       {

--- a/spec/unit/facter/java_libjvm_path_spec.rb
+++ b/spec/unit/facter/java_libjvm_path_spec.rb
@@ -11,14 +11,14 @@ describe 'java_libjvm_path' do
 
   context 'when libjvm exists' do
     it do
-      allow(Dir).to receive(:glob).with("#{java_default_home}/jre/lib/**/libjvm.so").and_return(['/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so'])
+      allow(Dir).to receive(:glob).with("#{java_default_home}/**/lib/**/libjvm.so").and_return(['/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so'])
       expect(Facter.value(:java_libjvm_path)).to eql '/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server'
     end
   end
 
   context 'when libjvm does not exist' do
     it do
-      allow(Dir).to receive(:glob).with("#{java_default_home}/jre/lib/**/libjvm.so").and_return([])
+      allow(Dir).to receive(:glob).with("#{java_default_home}/**/lib/**/libjvm.so").and_return([])
       expect(Facter.value(:java_libjvm_path)).to be nil
     end
   end


### PR DESCRIPTION
When trying to implement the current master branch in our setup, I noticed the facts don't work for debian buster since the output format of the default openjdk 11 command "java -version" changed. I added a condition to check the format, and see if it starts with 1 (like in 1.8.0_144) or the newer format with > 1 (like 11.0.4). 

This adds the java version facts resolving for debian buster and should not break it for existing implementations.