### PR TITLE
(maint) Merge back for release version 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,13 @@ All notable changes to this project will be documented in this file. The format 
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-java/compare/v5.0.1...v6.0.0)
 
-### Changed
-
-- pdksync - FM-8499 - remove ubuntu14 support [\#398](https://github.com/puppetlabs/puppetlabs-java/pull/398) ([lionce](https://github.com/lionce))
-
 ### Added
 
-- \(FM-8676\) - Support added for CentOS 8 [\#399](https://github.com/puppetlabs/puppetlabs-java/pull/399) ([david22swan](https://github.com/david22swan))
+- \(FM-8676\) Add CentOS 8 to supported OS list [\#399](https://github.com/puppetlabs/puppetlabs-java/pull/399) ([david22swan](https://github.com/david22swan))
 - FM-8403 - add support Debain10 [\#387](https://github.com/puppetlabs/puppetlabs-java/pull/387) ([lionce](https://github.com/lionce))
 
 ### Fixed
 
-- MODULES-10062 - fix acceptance tests on sles [\#397](https://github.com/puppetlabs/puppetlabs-java/pull/397) ([lionce](https://github.com/lionce))
 - we need to check if java\_default\_home has a value before we attempt t… [\#391](https://github.com/puppetlabs/puppetlabs-java/pull/391) ([robmbrooks](https://github.com/robmbrooks))
 - Add support for java 11, the default in debian buster 10 [\#386](https://github.com/puppetlabs/puppetlabs-java/pull/386) ([jhooyberghs](https://github.com/jhooyberghs))
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-java",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "author": "puppetlabs",
   "summary": "Installs the correct Java package on various platforms.",
   "license": "Apache-2.0",


### PR DESCRIPTION
PR tests are being temperamental. Eventually managed to get a successful run kicked off locally:
```
➜  puppetlabs-java git:(release) ✗ RSPEC_DEBUG=true bundle exec rake litmus:acceptance:parallel
┌ [✔] Running against 19 targets.
├── [✔] despondent-trio.delivery.puppetlabs.net, redhat-6-x86_64
├── [✔] sectarian-worth.delivery.puppetlabs.net, redhat-7-x86_64
├── [✔] removable-opera.delivery.puppetlabs.net, redhat-8-x86_64
├── [✔] dank-journalism.delivery.puppetlabs.net, centos-6-x86_64
├── [✔] dim-homage.delivery.puppetlabs.net, centos-7-x86_64
├── [✔] brighter-septum.delivery.puppetlabs.net, centos-8-x86_64
├── [✔] dumb-heartbeat.delivery.puppetlabs.net, oracle-6-x86_64
├── [✔] keen-serenity.delivery.puppetlabs.net, oracle-7-x86_64
├── [✔] deaf-fostering.delivery.puppetlabs.net, scientific-6-x86_64
├── [✔] rarer-laudanum.delivery.puppetlabs.net, scientific-7-x86_64
├── [✔] even-blacksmith.delivery.puppetlabs.net, debian-8-x86_64
├── [✔] limp-strategy.delivery.puppetlabs.net, debian-9-x86_64
├── [✔] bully-coaching.delivery.puppetlabs.net, debian-10-x86_64
├── [✔] scanty-converse.delivery.puppetlabs.net, ubuntu-1404-x86_64
├── [✔] ionic-grunting.delivery.puppetlabs.net, ubuntu-1604-x86_64
├── [✔] stylistic-copy.delivery.puppetlabs.net, ubuntu-1804-x86_64
├── [✔] heady-redwood.delivery.puppetlabs.net, sles-11-x86_64
├── [✔] noble-hammer.delivery.puppetlabs.net, sles-12-x86_64
└── [✔] brute-rabbeting.delivery.puppetlabs.net, sles-15-x86_64
================
Successful on 19 nodes: ["keen-serenity.delivery.puppetlabs.net, oracle-7-x86_64", "scanty-converse.delivery.puppetlabs.net, ubuntu-1404-x86_64", "even-blacksmith.delivery.puppetlabs.net, debian-8-x86_64", "heady-redwood.delivery.puppetlabs.net, sles-11-x86_64", "despondent-trio.delivery.puppetlabs.net, redhat-6-x86_64", "brighter-septum.delivery.puppetlabs.net, centos-8-x86_64", "stylistic-copy.delivery.puppetlabs.net, ubuntu-1804-x86_64", "limp-strategy.delivery.puppetlabs.net, debian-9-x86_64", "bully-coaching.delivery.puppetlabs.net, debian-10-x86_64", "noble-hammer.delivery.puppetlabs.net, sles-12-x86_64", "dumb-heartbeat.delivery.puppetlabs.net, oracle-6-x86_64", "deaf-fostering.delivery.puppetlabs.net, scientific-6-x86_64", "ionic-grunting.delivery.puppetlabs.net, ubuntu-1604-x86_64", "dank-journalism.delivery.puppetlabs.net, centos-6-x86_64", "rarer-laudanum.delivery.puppetlabs.net, scientific-7-x86_64", "sectarian-worth.delivery.puppetlabs.net, redhat-7-x86_64", "removable-opera.delivery.puppetlabs.net, redhat-8-x86_64", "dim-homage.delivery.puppetlabs.net, centos-7-x86_64", "brute-rabbeting.delivery.puppetlabs.net, sles-15-x86_64"]
```