### PR TITLE
Support SAP Javas (sapjvm / sapmachine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ java::download { 'jdk8' :
 }
 ```
 
+## AdoptOpenJDK
+
 The defined type `java::adopt` installs one or more versions of AdoptOpenJDK Java. `java::adopt` depends on [puppet/archive](https://github.com/voxpupuli/puppet-archive).
 
 ```puppet
@@ -70,7 +72,7 @@ java::adopt { 'jdk11' :
   java => 'jdk',
 }
 ```
-#TODO
+
 To install a specific release of a AdoptOpenJDK Java version, e.g. 8u202-b08, provide both parameters `version_major` and `version_minor` as follows:
 
 ```puppet
@@ -99,6 +101,58 @@ java::adopt { 'jdk8' :
   ensure  => 'present',
   version_major => '8u202',
   version_minor => 'b08',
+  java => 'jdk',
+  manage_basedir => true,
+  basedir => '/custom/java',
+}
+```
+
+## SAP Java (sapjvm / sapmachine)
+
+SAP also offers JVM distributions. They are mostly required for their SAP products. In earlier versions it is called "sapjvm", in newer versions they call it "sapmachine".
+
+The defined type `java::sap` installs one or more versions of sapjvm (if version 7 or 8) or sapmachine (if version > 8) Java. `java::sap` depends on [puppet/archive](https://github.com/voxpupuli/puppet-archive).
+By using this defined type with versions 7 or 8 you agree with the EULA presented at https://tools.hana.ondemand.com/developer-license-3_1.txt!
+
+```puppet
+java::sap { 'sapjvm8' :
+  ensure  => 'present',
+  version => '8',
+  java => 'jdk',
+}
+
+java::sap { 'sapmachine11' :
+  ensure  => 'present',
+  version => '11',
+  java => 'jdk',
+}
+```
+
+To install a specific release of a SAP Java version, e.g. sapjvm 8.1.063, provide parameter `version_full`:
+
+```puppet
+java::sap { 'jdk8' :
+  ensure  => 'present',
+  version_full => '8.1.063',
+  java => 'jdk',
+}
+```
+
+To install SAP Java to a non-default basedir (defaults: /usr/lib/jvm for Debian; /usr/java for RedHat):
+```puppet
+java::adopt { 'sapjvm8' :
+  ensure  => 'present',
+  version_full => '8.1.063',
+  java => 'jdk',
+  basedir => '/custom/java',
+}
+```
+
+To ensure that a custom basedir is a directory before SAP Java is installed (note: manage separately for custom ownership or perms):
+```puppet
+java::adopt { 'sapjvm8' :
+  ensure  => 'present',
+  version_full => '8.1.063',
   java => 'jdk',
   manage_basedir => true,
   basedir => '/custom/java',
@@ -160,6 +214,17 @@ AdoptOpenJDK Java is supported on:
 * Red Hat Enterprise Linux (RHEL)
 * Amazon Linux
 * Debian
+
+SAP Java 7 and 8 (=sapjvm) are supported (by SAP) on:
+
+* SLES 12, 15
+* Oracle Linux 7, 8
+* Red Hat Enterprise Linux (RHEL) 7, 8
+
+(however installations on other distributions mostly also work well)
+
+For SAP Java > 8 (=sapmachine) please refer to the OpenJDK list as it is based on OpenJDK and has no special requirements.
+
 
 ### Known issues
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -20,6 +20,7 @@ options, even though those are not in the package repositories.
 
 * [`java::adopt`](#javaadopt): Install one or more versions of AdoptOpenJDK Java.
 * [`java::download`](#javadownload): Installs Java from a url location.
+* [`java::sap`](#javasap): Install one or more versions of SAPJVM or Sapmachine
 
 ## Classes
 
@@ -325,6 +326,96 @@ in a few installation package flavors and we need to account for them.
 Optional forced package types: rpm, rpmbin, tar.gz
 
 Default value: `undef`
+
+##### `manage_symlink`
+
+Data type: `Any`
+
+Whether to manage a symlink that points to the installation directory.  Defaults to false.
+
+Default value: `false`
+
+##### `symlink_name`
+
+Data type: `Any`
+
+The name for the optional symlink in the installation directory.
+
+Default value: `undef`
+
+### java::sap
+
+Defined Type java::sap
+
+#### Parameters
+
+The following parameters are available in the `java::sap` defined type.
+
+##### `ensure`
+
+Data type: `Any`
+
+Install or remove the package.
+
+Default value: 'present'
+
+##### `version`
+
+Data type: `Any`
+
+Version of Java to install, e.g. '8' or '9'. Default values for full versions will be used.
+
+Default value: '8'
+
+##### `version_full`
+
+Data type: `Any`
+
+Major version which should be installed, e.g. '8.1.063' or '11.0.7'. If used, "version" parameter is ignored.
+
+Default value: `undef`
+
+##### `java`
+
+Data type: `Any`
+
+Type of Java Edition to install, jdk or jre.
+
+Default value: 'jdk'
+
+##### `proxy_server`
+
+Data type: `Any`
+
+Specify a proxy server, with port number if needed. ie: https://example.com:8080. (passed to archive)
+
+Default value: `undef`
+
+##### `proxy_type`
+
+Data type: `Any`
+
+Proxy server type (none|http|https|ftp). (passed to archive)
+
+Default value: `undef`
+
+##### `basedir`
+
+Data type: `Any`
+
+Directory under which the installation will occur. If not set, defaults to
+/usr/lib/jvm for Debian and /usr/java for RedHat.
+
+Default value: `undef`
+
+##### `manage_basedir`
+
+Data type: `Any`
+
+Whether to manage the basedir directory.  Defaults to false.
+Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
+
+Default value: `true`
 
 ##### `manage_symlink`
 

--- a/manifests/sap.pp
+++ b/manifests/sap.pp
@@ -1,0 +1,227 @@
+# Defined Type java::sap
+#
+# @summary
+#   Install one or more versions of SAPJVM or Sapmachine
+#
+# @param ensure
+#   Install or remove the package.
+#
+# @param version
+#   Version of Java to install, e.g. '8' or '9'. Default values for full versions will be used.
+#
+# @param version_full
+#   Major version which should be installed, e.g. '8.1.063' or '11.0.7'. If used, "version" parameter is ignored.
+#
+# @param java
+#   Type of Java Edition to install, jdk or jre.
+#
+# @param proxy_server
+#   Specify a proxy server, with port number if needed. ie: https://example.com:8080. (passed to archive)
+#
+# @param proxy_type
+#   Proxy server type (none|http|https|ftp). (passed to archive)
+#
+# @param basedir
+#   Directory under which the installation will occur. If not set, defaults to
+#   /usr/lib/jvm for Debian and /usr/java for RedHat.
+#
+# @param manage_basedir
+#   Whether to manage the basedir directory.  Defaults to false.
+#   Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
+#
+# @param manage_symlink
+#   Whether to manage a symlink that points to the installation directory.  Defaults to false.
+#
+# @param symlink_name
+#   The name for the optional symlink in the installation directory.
+#
+define java::sap (
+  $ensure         = 'present',
+  $version        = '8',
+  $version_full   = undef,
+  $java           = 'jdk',
+  $proxy_server   = undef,
+  $proxy_type     = undef,
+  $basedir        = undef,
+  $manage_basedir = true,
+  $manage_symlink = false,
+  $symlink_name   = undef,
+) {
+
+  # archive module is used to download the java package
+  include ::archive
+
+  # validate java edition to download
+  if $java !~ /(jre|jdk)/ {
+    fail('java must be either jre or jdk.')
+  }
+
+  # determine version and installation path
+  if $version_full {
+
+    $_version_array = $version_full.scanf('%i')
+    $_version_int = $_version_array[0]
+
+    $_version_full = $version_full
+
+  } else {
+    $_version = $version
+    $_version_int = Numeric($_version)
+    # use default versions if full version parameter is not provided
+    case $version {
+      '7' : {
+        $_version_full = '7.1.070'
+        if ($java != 'jdk') {
+          fail('java parameter is not jdk. jre is not supported on version 7')
+        }
+      }
+      '8' : {
+        $_version_full = '8.1.063'
+        if ($java != 'jdk') {
+          fail('java parameter is not jdk. jre is not supported on version 8')
+        }
+      }
+      '11' : {
+        $_version_full = '11.0.7'
+      }
+      '14' : {
+        $_version_full = '14.0.1'
+      }
+      default : {
+        fail("${version} not yet supported by module")
+      }
+    }
+  }
+
+  # extracted folders look like this:
+  #  sapjvm_8
+  #  sapmachine-jdk-11.0.7
+  if ($_version_int == 7 or $_version_int == 8) {
+    $_creates_folder = "sapjvm_${_version_int}"
+  } else {
+    $_creates_folder = "sapmachine-${java}-${_version_full}"
+  }
+
+  # determine destination directory based on OS
+  case $facts['kernel'] {
+    'Linux' : {
+      case $facts['os']['family'] {
+        'RedHat', 'Amazon' : {
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/java'
+          }
+        }
+        'Debian' : {
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/lib/jvm'
+          }
+        }
+        default : {
+          fail ("unsupported os family ${$facts['os']['name']}") }
+      }
+
+      $creates_path = "${_basedir}/${_creates_folder}"
+    }
+    default : {
+      fail ( "unsupported platform ${$facts['kernel']}" ) }
+  }
+
+  $_os_architecture = $facts['os']['architecture'] ? {
+    undef => $facts['architecture'],
+    default => $facts['os']['architecture']
+  }
+
+  if ($_os_architecture != 'x86_64' and $_os_architecture != 'amd64') {
+    fail ("unsupported platform ${_os_architecture}")
+  }
+
+  # download links look like this (examples):
+  # https://tools.hana.ondemand.com/additional/sapjvm-8.1.063-linux-x64.zip
+  # https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.7/sapmachine-jre-11.0.7_linux-x64_bin.tar.gz
+  # https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.7/sapmachine-jdk-11.0.7_linux-x64_bin.tar.gz
+  # https://github.com/SAP/SapMachine/releases/download/sapmachine-14.0.1/sapmachine-jdk-14.0.1_linux-x64_bin.tar.gz
+
+  # cookie is currently at version 3.1, but may be changed one day. It is only required for download at SAP.
+  # by using this module you agree with the EULA presented at tools.hana.ondemand.com download page!
+  # Github does not require it
+
+  if ( $_version_int == 7 or $_version_int == 8 ) {
+    # sapjvm download
+    $archive_filename = "sapjvm-${_version_full}-linux-x64.zip"
+    $source = "https://tools.hana.ondemand.com/additional/${archive_filename}"
+    $cookie = 'eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt'
+
+    if (!defined(Package['unzip'])) {
+      package { 'unzip':
+        ensure => 'present',
+        before => Archive["/tmp/${archive_filename}"],
+      }
+    }
+  } else {
+    $archive_filename = "sapmachine-${java}-${_version_full}_linux-x64_bin.tar.gz"
+    $source = "https://github.com/SAP/SapMachine/releases/download/sapmachine-${_version_full}/${archive_filename}"
+    $cookie = undef
+
+    if (!defined(Package['tar'])) {
+      package { 'tar':
+        ensure => 'present',
+        before => Archive["/tmp/${archive_filename}"],
+      }
+    }
+    if (!defined(Package['gzip'])) {
+      package { 'gzip':
+        ensure => 'present',
+        before => Archive["/tmp/${archive_filename}"],
+      }
+    }
+  }
+
+  case $ensure {
+    'present' : {
+      case $facts['kernel'] {
+        'Linux' : {
+          if ($manage_basedir or $facts['os']['family'] == 'Debian'){
+            if (!defined(File[$_basedir])) {
+              file { $_basedir:
+                ensure => 'directory',
+                before => Archive["/tmp/${archive_filename}"],
+              }
+            }
+          }
+
+          archive { "/tmp/${archive_filename}" :
+            ensure       => present,
+            source       => $source,
+            extract      => true,
+            extract_path => $_basedir,
+            cleanup      => false,
+            creates      => $creates_path,
+            cookie       => $cookie,
+            proxy_server => $proxy_server,
+            proxy_type   => $proxy_type,
+          }
+
+          if ($manage_symlink and $symlink_name) {
+            file { "${_basedir}/${symlink_name}":
+              ensure  => link,
+              target  => $creates_path,
+              require => Archive["/tmp/${archive_filename}"],
+            }
+          }
+
+        }
+        default : {
+          fail ("unsupported platform ${$facts['kernel']}")
+        }
+      }
+    }
+    default : {
+      notice ("Action ${ensure} not supported.")
+    }
+  }
+
+}

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -138,6 +138,55 @@ install_adopt_jdk_jre = <<EOL
   }
 EOL
 
+sap_enabled = true
+sap_version7 = '7'
+sap_version7_full = '7.1.070'
+sap_version8 = '8'
+sap_version8_full = '8.1.063'
+sap_version11 = '11'
+sap_version11_full = '11.0.7'
+sap_version14 = '14'
+sap_version14_full = '14.0.1'
+
+install_sap_jdk_jre = <<EOL
+  java::sap {
+    'test_sap_jdk_version7':
+      version       => '#{sap_version7}',
+      version_full  => '#{sap_version7_full}',
+      java          => 'jdk',
+  }
+  java::sap {
+    'test_sap_jdk_version8':
+      version       => '#{sap_version8}',
+      version_full  => '#{sap_version8_full}',
+      java          => 'jdk',
+  }
+  java::sap {
+    'test_sap_jre_version11':
+      version       => '#{sap_version11}',
+      version_full  => '#{sap_version11_full}',
+      java          => 'jre',
+  }
+  java::sap {
+    'test_sap_jdk_version11':
+      version       => '#{sap_version11}',
+      version_full  => '#{sap_version11_full}',
+      java          => 'jdk',
+  }
+  java::sap {
+    'test_sap_jre_version14':
+      version       => '#{sap_version14}',
+      version_full  => '#{sap_version14_full}',
+      java          => 'jre',
+  }
+  java::sap {
+    'test_sap_jdk_version14':
+      version       => '#{sap_version14}',
+      version_full  => '#{sap_version14_full}',
+      java          => 'jdk',
+  }
+EOL
+
 context 'installing java jre', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
   it 'installs jre' do
     idempotent_apply(java_class_jre)
@@ -217,5 +266,15 @@ context 'java::adopt', if: adopt_enabled, unless: UNSUPPORTED_PLATFORMS.include?
 
   it 'installs adopt jdk and jre' do
     idempotent_apply(install_adopt_jdk_jre)
+  end
+end
+
+context 'java::adopt', if: sap_enabled, unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
+  let(:install_path) do
+    (os[:family] == 'redhat') ? '/usr/java' : '/usr/lib/jvm'
+  end
+
+  it 'installs adopt jdk and jre' do
+    idempotent_apply(install_sap_jdk_jre)
   end
 end

--- a/spec/defines/sap_spec.rb
+++ b/spec/defines/sap_spec.rb
@@ -1,0 +1,255 @@
+require 'spec_helper'
+
+describe 'java::sap', type: :define do
+  context 'with CentOS 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'RedHat', architecture: 'x86_64', name: 'CentOS', release: { full: '6.0' } } } }
+
+    context 'when manage_symlink is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '11',
+          java: 'jdk',
+          basedir: '/usr/java',
+          manage_symlink: true,
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk11_symlink' }
+
+      it { is_expected.to contain_file('/usr/java/java_home') }
+    end
+
+    context 'when manage_symlink is not set' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jdk' } }
+      let(:title) { 'jdk11_nosymlink' }
+
+      it { is_expected.not_to contain_file('/usr/java/java_home') }
+    end
+
+    context 'when sapjvm 7' do
+      let(:params) { { ensure: 'present', version: '7', java: 'jdk' } }
+      let(:title) { 'jdk7' }
+
+      it { is_expected.to contain_archive('/tmp/sapjvm-7.1.070-linux-x64.zip') }
+    end
+
+    context 'when sapjvm 8' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jdk' } }
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/sapjvm-8.1.063-linux-x64.zip') }
+    end
+
+    context 'when sapmachine 11 jdk' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jdk' } }
+      let(:title) { 'jdk11' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jdk-11.0.7_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 11 jre' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jre-11.0.7_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 14 jdk' do
+      let(:params) { { ensure: 'present', version: '14', java: 'jdk' } }
+      let(:title) { 'jdk14' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jdk-14.0.1_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 14 jre' do
+      let(:params) { { ensure: 'present', version: '14', java: 'jre' } }
+      let(:title) { 'jre14' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jre-14.0.1_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_full: '11.0.7',
+          java: 'jdk',
+        }
+      end
+      let(:title) { 'jdk1107' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::sap {
+          'jdk1106':
+            ensure       => 'present',
+            version_full => '11.0.6',
+            java         => 'jdk',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+
+    context 'when specifying basedir' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '8',
+          java: 'jdk',
+          basedir: '/usr/java',
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/sapjvm-8.1.063-linux-x64.zip') }
+    end
+    context 'when manage_basedir is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version: '8',
+          java: 'jdk',
+          basedir: '/usr/java',
+          manage_basedir: true,
+        }
+      end
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_file('/usr/java') }
+    end
+  end
+
+  context 'with Ubuntu 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'Debian', architecture: 'amd64', name: 'Ubuntu', release: { full: '16.04' } } } }
+
+    context 'when sapjvm 7' do
+      let(:params) { { ensure: 'present', version: '7', java: 'jdk' } }
+      let(:title) { 'jdk7' }
+
+      it { is_expected.to contain_archive('/tmp/sapjvm-7.1.070-linux-x64.zip') }
+    end
+
+    context 'when sapjvm 8' do
+      let(:params) { { ensure: 'present', version: '8', java: 'jdk' } }
+      let(:title) { 'jdk8' }
+
+      it { is_expected.to contain_archive('/tmp/sapjvm-8.1.063-linux-x64.zip') }
+    end
+
+    context 'when sapmachine 11 jdk' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jdk' } }
+      let(:title) { 'jdk11' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jdk-11.0.7_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 11 jre' do
+      let(:params) { { ensure: 'present', version: '11', java: 'jre' } }
+      let(:title) { 'jre11' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jre-11.0.7_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 14 jdk' do
+      let(:params) { { ensure: 'present', version: '14', java: 'jdk' } }
+      let(:title) { 'jdk14' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jdk-14.0.1_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when sapmachine 14 jre' do
+      let(:params) { { ensure: 'present', version: '14', java: 'jre' } }
+      let(:title) { 'jre14' }
+
+      it { is_expected.to contain_archive('/tmp/sapmachine-jre-14.0.1_linux-x64_bin.tar.gz') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_full: '11.0.7',
+          java: 'jdk',
+        }
+      end
+      let(:title) { 'jdk1107' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::sap {
+          'jdk1106':
+            ensure       => 'present',
+            version_full => '11.0.6',
+            java         => 'jdk',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+  end
+  describe 'incompatible OSes' do
+    [
+      {
+        kernel: 'Windows',
+        os: {
+          family: 'Windows',
+          name: 'Windows',
+          release: {
+            full: '8.1',
+          },
+        },
+      },
+      {
+        kernel: 'Darwin',
+        os: {
+          family: 'Darwin',
+          name: 'Darwin',
+          release: {
+            full: '13.3.0',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '7100-02-00-000',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '6100-07-04-1216',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '5300-12-01-1016',
+          },
+        },
+      },
+    ].each do |facts|
+      let(:facts) { facts }
+      let(:title) { 'jdk' }
+
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
+        expect { catalogue }.to raise_error Puppet::Error, %r{unsupported platform}
+      end
+    end
+  end
+end


### PR DESCRIPTION
In big companies you might need to install the SAP flavours of Java, because their products require it. Usually their product installers do it themselves but in certain cases (f.e. when using SAP commerce, in former times called Hybris) you might need to install it by yourself - at least in our company.

This PR extends the puppet module to support installing those Javas.