### PR TITLE
(IAC-1138) Add scanf gem dependency

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -47,6 +47,8 @@ Gemfile:
     - gem: bolt
       version: '2.32.0'
       condition: Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
+    - gem: scanf
+      condition: Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
   gem "puppet_litmus",                                           require: false, git: 'https://github.com/puppetlabs/puppet_litmus', ref: 'main' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
   gem "bolt", '2.32.0',                                          require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
+  gem "scanf",                                                   require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -82,6 +82,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g874030e",
+  "template-ref": "heads/main-0-gd093482",
   "pdk-version": "1.18.1"
 }


### PR DESCRIPTION
Prior to this commit, spec tests would fail on Ruby 2.7 when puppet
attempted to load the scanf gem.

This change adds the scanf gem as a dependency for this module when
running in a Ruby 2.7 environment