### PR TITLE
pdksync - (maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -30,7 +29,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -46,7 +44,8 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -69,8 +68,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11",
-        "12",
         "15"
       ]
     }


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
