### PR TITLE
add url parameter for adoptopenjdk

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -127,6 +127,7 @@ The following parameters are available in the `java::adopt` defined type:
 * [`java`](#java)
 * [`proxy_server`](#proxy_server)
 * [`proxy_type`](#proxy_type)
+* [`url`](#url)
 * [`basedir`](#basedir)
 * [`manage_basedir`](#manage_basedir)
 * [`package_type`](#package_type)
@@ -186,6 +187,14 @@ Default value: ``undef``
 Data type: `Any`
 
 Proxy server type (none|http|https|ftp). (passed to archive)
+
+Default value: ``undef``
+
+##### <a name="url"></a>`url`
+
+Data type: `Any`
+
+Full URL
 
 Default value: ``undef``
 
@@ -481,4 +490,3 @@ Data type: `Any`
 The name for the optional symlink in the installation directory.
 
 Default value: ``undef``
-

--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -24,6 +24,9 @@
 # @param proxy_type
 #   Proxy server type (none|http|https|ftp). (passed to archive)
 #
+# @param url
+#   Full URL
+#
 # @param basedir
 #   Directory under which the installation will occur. If not set, defaults to
 #   /usr/lib/jvm for Debian and /usr/java for RedHat.
@@ -51,6 +54,7 @@ define java::adopt (
   $java           = 'jdk',
   $proxy_server   = undef,
   $proxy_type     = undef,
+  $url            = undef,
   $basedir        = undef,
   $manage_basedir = true,
   $package_type   = undef,
@@ -234,7 +238,15 @@ define java::adopt (
     $spacer = '%2B'
     $download_folder_prefix = 'jdk-'
   }
-  $source = "https://github.com/AdoptOpenJDK/openjdk${_version}-binaries/releases/download/${download_folder_prefix}${release_major}${spacer}${release_minor}/${package_name}"
+
+  # if complete URL is provided, use this value for source in archive resource
+  if $url {
+    $source = $url
+  }
+  else {
+    $source = "https://github.com/AdoptOpenJDK/openjdk${_version}-binaries/releases/download/${download_folder_prefix}${release_major}${spacer}${release_minor}/${package_name}"
+    notice ("Default source url : ${source}")
+  }
 
   # full path to the installer
   $destination = "${destination_dir}${package_name}"


### PR DESCRIPTION
Hi,

when using AdoptOpenJDK, there is currently no possibility to download tar.gz from an internal repository, instead of github.com/AdoptOpenJDK.
For this purpose, an URL parameter already exists for oracleJDK (download.pp). This PR do the same for adoptopenjdk.
Thanks
