### PR TITLE
Allow archive 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.1.0 < 6.0.0"
+      "version_requirement": ">= 1.1.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
A new major version of the archive module was released which add support for new operating systems and drop support of legacy ones.

Installing the latest version of the archive and java module is currently not possible due to maximum version mismatch, example from voxpupuli/puppet-jira CI:

```
centos7-64.example.com 16:43:48$ puppet module install puppet-archive -v 6.0.1
  Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  Notice: Downloading from forgeapi.puppet.com ...
  Notice: Installing -- do not interrupt ...
  /etc/puppetlabs/code/environments/production/modules
  └─┬ puppet-archive (v6.0.1)
    └── puppetlabs-stdlib (v8.0.0)

centos7-64.example.com executed in 4.02 seconds
[...]
centos7-64.example.com 16:43:53$ puppet module install puppetlabs-java -v 7.1.1
  Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  Notice: Downloading from forgeapi.puppet.com ...
  Error: Could not install module 'puppetlabs-java' (v7.1.1)
    The requested version cannot satisfy one or more of the following installed modules:
      puppet-archive, installed: 6.0.1, expected: >= 1.1.0 < 6.0.0
  
    Use `puppet module install 'puppetlabs-java' --ignore-dependencies` to install only this module

centos7-64.example.com executed in 4.62 seconds
Exited: 1
```

A bugfix release of the java module would fix this issue.
