### PR TITLE
(MODULES-11234) Support Adoptium Temurin

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,56 @@ java::adopt { 'jdk8' :
 }
 ```
 
+## Adoptium Temurin
+
+Adoptium Temurin is the successor of AdoptOpenJDK and is supported using the defined type `java::adoptium`. It depends on [puppet/archive](https://github.com/voxpupuli/puppet-archive).
+
+The `java::adoptium` defined type expects a major, minor, patch and build version to download the specific release. It doesn't support jre downloads as the other distributions.
+
+```puppet
+java::adoptium { 'jdk16' :
+  ensure  => 'present',
+  version_major => '16',
+  version_minor => '0',
+  version_patch => '2',
+  version_build => '7',
+}
+java::adoptium { 'jdk17' :
+  ensure  => 'present',
+  version_major => '17',
+  version_minor => '0',
+  version_patch => '1',
+  version_build => '12',
+}
+```
+
+To install Adoptium to a non-default basedir (defaults: /usr/lib/jvm for Debian; /usr/java for RedHat):
+
+```puppet
+java::adoptium { 'jdk7' :
+  ensure  => 'present',
+  version_major => '17',
+  version_minor => '0',
+  version_patch => '1',
+  version_build => '12',
+  basedir => '/custom/java',
+}
+```
+
+To ensure that a custom basedir is a directory before Adoptium is installed (note: manage separately for custom ownership or perms):
+
+```puppet
+java::adoptium { 'jdk8' :
+  ensure  => 'present',
+  version_major => '17',
+  version_minor => '0',
+  version_patch => '1',
+  version_build => '12',
+  manage_basedir => true,
+  basedir => '/custom/java',
+}
+```
+
 ## SAP Java (sapjvm / sapmachine)
 
 SAP also offers JVM distributions. They are mostly required for their SAP products. In earlier versions it is called "sapjvm", in newer versions they call it "sapmachine".
@@ -215,6 +265,13 @@ AdoptOpenJDK Java is supported on:
 * Amazon Linux
 * Debian
 
+Adoptium Temurin Java is supported on:
+
+* CentOS
+* Red Hat Enterprise Linux (RHEL)
+* Amazon Linux
+* Debian
+
 SAP Java 7 and 8 (=sapjvm) are supported (by SAP) on:
 
 * SLES 12, 15
@@ -224,7 +281,6 @@ SAP Java 7 and 8 (=sapjvm) are supported (by SAP) on:
 (however installations on other distributions mostly also work well)
 
 For SAP Java > 8 (=sapmachine) please refer to the OpenJDK list as it is based on OpenJDK and has no special requirements.
-
 
 ### Known issues
 

--- a/manifests/adoptium.pp
+++ b/manifests/adoptium.pp
@@ -1,0 +1,190 @@
+# Defined Type java::adoptium
+#
+# @summary
+#   Install one or more versions of Adoptium Temurin OpenJDK (former AdoptOpenJDK).
+#
+# @param ensure
+#   Install or remove the package.
+#
+# @param version_major
+#   Major version which should be installed, e.g. '16' or '17'
+#
+# @param version_minor
+#   Minor version which should be installed, e.g. '0'
+#
+# @param version_patch
+#   Minor version which should be installed, e.g. '2'
+#
+# @param version_build
+#   Build version which should be installed, e.g. '07'
+#
+# @param proxy_server
+#   Specify a proxy server, with port number if needed. ie: https://example.com:8080. (passed to archive)
+#
+# @param proxy_type
+#   Proxy server type (none|http|https|ftp). (passed to archive)
+#
+# @param url
+#   Full URL
+#
+# @param basedir
+#   Directory under which the installation will occur. If not set, defaults to
+#   /usr/lib/jvm for Debian and /usr/java for RedHat.
+#
+# @param manage_basedir
+#   Whether to manage the basedir directory.  Defaults to false.
+#   Note: /usr/lib/jvm is managed for Debian by default, separate from this parameter.
+#
+# @param manage_symlink
+#   Whether to manage a symlink that points to the installation directory.  Defaults to false.
+#
+# @param symlink_name
+#   The name for the optional symlink in the installation directory.
+#
+define java::adoptium (
+  $ensure         = 'present',
+  $version_major  = undef,
+  $version_minor  = undef,
+  $version_patch  = undef,
+  $version_build  = undef,
+  $proxy_server   = undef,
+  $proxy_type     = undef,
+  $url            = undef,
+  $basedir        = undef,
+  $manage_basedir = true,
+  $manage_symlink = false,
+  $symlink_name   = undef,
+) {
+
+  # archive module is used to download the java package
+  include ::archive
+
+  $install_path = "jdk-${version_major}.${version_minor}.${version_patch}+${version_build}"
+
+  # determine package type (exe/tar/rpm), destination directory based on OS
+  case $facts['kernel'] {
+    'Linux' : {
+      case $facts['os']['family'] {
+        'RedHat', 'Amazon' : {
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/java'
+          }
+        }
+        'Debian' : {
+          if $basedir {
+            $_basedir = $basedir
+          } else {
+            $_basedir = '/usr/lib/jvm'
+          }
+        }
+        default : {
+          fail ("unsupported platform ${$facts['os']['name']}") }
+      }
+
+      $creates_path = "${_basedir}/${install_path}"
+      $os = 'linux_hotspot'
+    }
+    default : {
+      fail ( "unsupported platform ${$facts['kernel']}" ) }
+  }
+
+  # set java architecture nomenclature
+  $os_architecture = $facts['os']['architecture'] ? {
+    undef => $facts['architecture'],
+    default => $facts['os']['architecture']
+  }
+
+  case $os_architecture {
+    'i386' : { $arch = 'x86-32' }
+    'x86_64' : { $arch = 'x64' }
+    'amd64' : { $arch = 'x64' }
+    default : {
+      fail ("unsupported platform ${$os_architecture}")
+    }
+  }
+
+  # package name and path for download from github
+  #
+  # following are build based on this real life example full URLs:
+  #
+  # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz
+  # https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_alpine-linux_hotspot_16.0.2_7.tar.gz
+
+  $package_name = "OpenJDK${version_major}U-jdk_${arch}_${os}_${version_major}.${version_minor}.${version_patch}_${version_build}.tar.gz"
+
+  # if complete URL is provided, use this value for source in archive resource
+  if $url {
+    $source = $url
+  }
+  else {
+    $source = "https://github.com/adoptium/temurin${version_major}-binaries/releases/download/jdk-${version_major}.${version_minor}.${version_patch}%2B${version_build}/${package_name}"
+    notice ("Default source url : ${source}")
+  }
+
+  # full path to the installer
+  $destination = "/tmp/${package_name}"
+  notice ("Destination is ${destination}")
+
+  case $ensure {
+    'present' : {
+      archive { $destination :
+        ensure       => present,
+        source       => $source,
+        extract_path => '/tmp',
+        cleanup      => false,
+        creates      => $creates_path,
+        proxy_server => $proxy_server,
+        proxy_type   => $proxy_type,
+      }
+      case $facts['kernel'] {
+        'Linux' : {
+          case $facts['os']['family'] {
+            'Debian' : {
+              ensure_resource('file', $_basedir, {
+                ensure => directory,
+              })
+              $install_requires = [Archive[$destination], File[$_basedir]]
+            }
+            default : {
+              $install_requires = [Archive[$destination]]
+            }
+          }
+
+          if $manage_basedir {
+            if (!defined(File[$_basedir])) {
+              file { $_basedir:
+                ensure => 'directory',
+                before => Exec["Install Adoptium Temurin java ${version_major} ${version_minor} ${version_patch} ${version_build}"],
+              }
+            }
+          }
+
+          exec { "Install Adoptium Temurin java ${version_major} ${version_minor} ${version_patch} ${version_build}" :
+            path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+            command => "tar -zxf ${destination} -C ${_basedir}",
+            creates => $creates_path,
+            require => $install_requires
+          }
+
+          if ($manage_symlink and $symlink_name) {
+            file { "${_basedir}/${symlink_name}":
+              ensure  => link,
+              target  => $creates_path,
+              require => Exec["Install Adoptium Temurin java ${version_major} ${version_minor} ${version_patch} ${version_build}"],
+            }
+          }
+
+        }
+        default : {
+          fail ("unsupported platform ${$facts['kernel']}")
+        }
+      }
+    }
+    default : {
+      notice ("Action ${ensure} not supported.")
+    }
+  }
+
+}

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -140,6 +140,27 @@ install_adopt_jdk_jre = <<EOL
   }
 EOL
 
+# Adoptium
+
+adoptium_enabled = true unless os[:family].casecmp('SLES').zero?
+
+install_adoptium_jdk = <<EOL
+  java::adoptium {
+    'test_adoptium_jdk_version16':
+      version_major => '16',
+      version_minor => '0',
+      version_patch => '2',
+      version_build => '7',
+  }
+  java::adoptium {
+    'test_adoptium_jdk_version17':
+      version_major => '17',
+      version_minor => '0',
+      version_patch => '1',
+      version_build => '12',
+  }
+EOL
+
 sap_enabled = true
 sap_version7 = '7'
 sap_version7_full = '7.1.072'
@@ -272,7 +293,21 @@ describe 'installing' do
     end
   end
 
-  context 'java::adopt', if: sap_enabled && ['Sles'].include?(os[:family]), unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
+  context 'java::adoptium', if: adoptium_enabled, unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
+    let(:install_path) do
+      (os[:family] == 'redhat') ? '/usr/java' : '/usr/lib/jvm'
+    end
+
+    let(:version_suffix) do
+      (os[:family] == 'redhat') ? '-amd64' : ''
+    end
+
+    it 'installs adopt jdk and jre' do
+      idempotent_apply(install_adoptium_jdk)
+    end
+  end
+
+  context 'java::sap', if: sap_enabled && ['Sles'].include?(os[:family]), unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) do
     let(:install_path) do
       (os[:family] == 'redhat') ? '/usr/java' : '/usr/lib/jvm'
     end

--- a/spec/defines/adoptium_spec.rb
+++ b/spec/defines/adoptium_spec.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'java::adoptium', type: :define do
+  context 'with CentOS 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'RedHat', architecture: 'x86_64', name: 'CentOS', release: { full: '6.0' } } } }
+
+    context 'when manage_symlink is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/java',
+          manage_symlink: true,
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk16_symlink' }
+
+      it { is_expected.to contain_file('/usr/java/java_home') }
+    end
+
+    context 'when manage_symlink is not set' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/java',
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk16_nosymlink' }
+
+      it { is_expected.not_to contain_file('/usr/java/java_home') }
+    end
+
+    context 'when Adoptium Temurin Java 16 JDK' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/java',
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').with_command('tar -zxf /tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').that_requires('Archive[/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz]') }
+    end
+
+    context 'when Adoptium Temurin Java 17 JDK' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '17',
+          version_minor: '0',
+          version_patch: '1',
+          version_build: '12',
+          basedir: '/usr/java',
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk17' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 17 0 1 12').with_command('tar -zxf /tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 17 0 1 12').that_requires('Archive[/tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz]') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::adoptium {
+          'jdk17':
+            ensure        => 'present',
+            version_major => '17',
+            version_minor => '0',
+            version_patch => '1',
+            version_build => '12',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+
+    context 'when specifying package_type tar.gz and basedir' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/java',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').with_command('tar -zxf /tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz -C /usr/java') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').that_requires('Archive[/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz]') }
+    end
+    context 'when manage_basedir is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/java',
+          manage_basedir: true,
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_file('/usr/java') }
+    end
+  end
+
+  context 'with Ubuntu 64-bit' do
+    let(:facts) { { kernel: 'Linux', os: { family: 'Debian', architecture: 'amd64', name: 'Ubuntu', release: { full: '16.04' } } } }
+
+    context 'when Adoptium Temurin Java 16 JDK' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').with_command('tar -zxf /tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').that_requires('Archive[/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz]') }
+    end
+
+    context 'when Adoptium Temurin Java 17 JDK' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '17',
+          version_minor: '0',
+          version_patch: '1',
+          version_build: '12',
+          symlink_name: 'java_home',
+        }
+      end
+      let(:title) { 'jdk17' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 17 0 1 12').with_command('tar -zxf /tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 17 0 1 12').that_requires('Archive[/tmp/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz]') }
+    end
+
+    context 'when installing multiple versions' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      let(:pre_condition) do
+        <<-EOL
+        java::adoptium {
+          'jdk17':
+            ensure        => 'present',
+            version_major => '17',
+            version_minor => '0',
+            version_patch => '1',
+            version_build => '12',
+        }
+        EOL
+      end
+
+      it { is_expected.to compile }
+    end
+
+    context 'when specifying package_type tar.gz and basedir' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/lib/jvm',
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_archive('/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').with_command('tar -zxf /tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz -C /usr/lib/jvm') }
+      it { is_expected.to contain_exec('Install Adoptium Temurin java 16 0 2 7').that_requires('Archive[/tmp/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz]') }
+    end
+    context 'when manage_basedir is set to true' do
+      let(:params) do
+        {
+          ensure: 'present',
+          version_major: '16',
+          version_minor: '0',
+          version_patch: '2',
+          version_build: '7',
+          basedir: '/usr/lib/jvm',
+          manage_basedir: true,
+        }
+      end
+      let(:title) { 'jdk16' }
+
+      it { is_expected.to contain_file('/usr/lib/jvm') }
+    end
+  end
+
+  describe 'incompatible OSes' do
+    [
+      {
+        kernel: 'Windows',
+        os: {
+          family: 'Windows',
+          name: 'Windows',
+          release: {
+            full: '8.1',
+          },
+        },
+      },
+      {
+        kernel: 'Darwin',
+        os: {
+          family: 'Darwin',
+          name: 'Darwin',
+          release: {
+            full: '13.3.0',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '7100-02-00-000',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '6100-07-04-1216',
+          },
+        },
+      },
+      {
+        kernel: 'AIX',
+        os: {
+          family: 'AIX',
+          name: 'AIX',
+          release: {
+            full: '5300-12-01-1016',
+          },
+        },
+      },
+    ].each do |facts|
+      let(:facts) { facts }
+      let(:title) { 'jdk' }
+
+      it "is_expected.to fail on #{facts[:os][:name]} #{facts[:os][:release][:full]}" do
+        expect { catalogue }.to raise_error Puppet::Error, %r{unsupported platform}
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for Adoptium Temurin (the new name of Adopt OpenJDK). I started testing from Adoptium 16 onwards, because previous versions can still be fetched from Adopt.

fixes MODULES-11234