### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/java_default_home.rb
+++ b/lib/facter/java_default_home.rb
@@ -16,7 +16,7 @@ Facter.add(:java_default_home) do
   confine kernel: ['Linux', 'OpenBSD']
   java_default_home = nil
   setcode do
-    java_bin = Facter::Util::Resolution.which('java').to_s.strip
+    java_bin = Facter::Core::Execution.which('java').to_s.strip
     if java_bin.empty?
       nil
     else

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -14,33 +14,13 @@
 # Notes:
 #   None
 Facter.add(:java_version) do
-  # the OS-specific overrides need to be able to return nil,
-  # to indicate "no java available". Usually returning nil
-  # would mean that facter falls back to a lower priority
-  # resolution, which would then trigger MODULES-2637. To
-  # avoid that, we confine the "default" here to not run
-  # on those OS.
-  # Additionally, facter versions prior to 2.0.1 only support
-  # positive matches, so this needs to be done manually in setcode.
   setcode do
-    unless ['darwin'].include? Facter.value(:kernel).downcase
-      version = nil
-      if Facter::Util::Resolution.which('java')
-        Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = Regexp.last_match(1) if %r{^.+ version \"(.+)\"} =~ line }
-      end
-      version
+    if ['darwin'].include? Facter.value(:kernel).downcase
+      return unless Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
+    else
+      return unless Facter::Core::Execution.which('java')
     end
-  end
-end
-
-Facter.add(:java_version) do
-  confine kernel: 'Darwin'
-  has_weight 100
-  setcode do
-    unless Facter::Util::Resolution.exec('/usr/libexec/java_home --failfast 2>&1').include?('Unable to find any JVMs matching version')
-      version = nil
-      Facter::Util::Resolution.exec('java -Xmx12m -version 2>&1').lines.each { |line| version = Regexp.last_match(1) if %r{^.+ version \"(.+)\"} =~ line }
-      version
-    end
+    version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
+    version[%r{\"(.*?)\"}, 1] if version
   end
 end

--- a/spec/unit/facter/java_default_home_spec.rb
+++ b/spec/unit/facter/java_default_home_spec.rb
@@ -17,7 +17,7 @@ end
 
 def symlink_and_test(symlink_path, java_home)
   File.symlink(symlink_path, './java_test')
-  expect(Facter::Util::Resolution).to receive(:which).with('java').and_return('./java_test')
+  expect(Facter::Core::Execution).to receive(:which).with('java').and_return('./java_test')
   expect(File).to receive(:realpath).with('./java_test').and_return(symlink_path)
   expect(Facter.value(:java_default_home)).to eql java_home
 end
@@ -48,8 +48,8 @@ describe 'java_default_home' do
 
   context 'when java not present, return nil' do
     it do
-      allow(Facter::Util::Resolution).to receive(:exec) # Catch all other calls
-      expect(Facter::Util::Resolution).to receive(:which).with('java').at_least(1).and_return(nil)
+      allow(Facter::Core::Execution).to receive(:execute) # Catch all other calls
+      expect(Facter::Core::Execution).to receive(:which).with('java').at_least(1).and_return(nil)
       expect(Facter.value(:java_default_home)).to be_nil
     end
   end

--- a/spec/unit/facter/java_version_spec.rb
+++ b/spec/unit/facter/java_version_spec.rb
@@ -21,12 +21,13 @@ describe 'java_version' do
     context 'on OpenBSD', with_env: true do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('OpenBSD')
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
       end
       let(:facts) { { operatingsystem: 'OpenBSD' } }
 
       it do
-        expect(Facter::Util::Resolution).to receive(:which).with('java').and_return('/usr/local/jdk-1.7.0/jre/bin/java')
-        expect(Facter::Util::Resolution).to receive(:exec).with('java -Xmx12m -version 2>&1').and_return(openjdk_7_output)
+        expect(Facter::Core::Execution).to receive(:which).with('java').and_return('/usr/local/jdk-1.7.0/jre/bin/java')
+        expect(Facter::Core::Execution).to receive(:execute).with('java -Xmx12m -version 2>&1').and_return(openjdk_7_output)
         expect(Facter.value(:java_version)).to eq('1.7.0_71')
       end
     end
@@ -37,20 +38,21 @@ describe 'java_version' do
       let(:facts) { { kernel: 'Darwin' } }
 
       it do
-        expect(Facter::Util::Resolution).to receive(:exec).with('/usr/libexec/java_home --failfast 2>&1').and_return('/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home')
-        expect(Facter::Util::Resolution).to receive(:exec).with('java -Xmx12m -version 2>&1').and_return(jdk_7_hotspot_output)
-        expect(Facter.value(:java_version)).to eql '1.7.0_71'
+        expect(Facter::Core::Execution).to receive(:execute).with('/usr/libexec/java_home --failfast', { on_fail: false }).and_return('/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home')
+        expect(Facter::Core::Execution).to receive(:execute).with('java -Xmx12m -version 2>&1').and_return(jdk_7_hotspot_output)
+        expect(Facter.value(:java_version)).to eq('1.7.0_71')
       end
     end
     context 'when on other systems' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('MyOS')
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
       end
       let(:facts) { { operatingsystem: 'MyOS' } }
 
       it do
-        expect(Facter::Util::Resolution).to receive(:which).with('java').and_return('/path/to/java')
-        expect(Facter::Util::Resolution).to receive(:exec).with('java -Xmx12m -version 2>&1').and_return(jdk_7_hotspot_output)
+        expect(Facter::Core::Execution).to receive(:which).with('java').and_return('/path/to/java')
+        expect(Facter::Core::Execution).to receive(:execute).with('java -Xmx12m -version 2>&1').and_return(jdk_7_hotspot_output)
         expect(Facter.value(:java_version)).to eq('1.7.0_71')
       end
     end
@@ -60,12 +62,13 @@ describe 'java_version' do
     context 'on OpenBSD', with_env: true do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('OpenBSD')
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
       end
       let(:facts) { { operatingsystem: 'OpenBSD' } }
 
       it do
-        allow(Facter::Util::Resolution).to receive(:exec) # Catch all other calls
-        allow(Facter::Util::Resolution).to receive(:which).and_return(nil)
+        allow(Facter::Core::Execution).to receive(:execute) # Catch all other calls
+        allow(Facter::Core::Execution).to receive(:which).and_return(nil)
         expect(Facter.value(:java_version)).to be_nil
       end
     end
@@ -76,18 +79,19 @@ describe 'java_version' do
       let(:facts) { { kernel: 'Darwin' } }
 
       it do
-        expect(Facter::Util::Resolution).to receive(:exec).with('/usr/libexec/java_home --failfast 2>&1').at_least(1).and_return('Unable to find any JVMs matching version "(null)".')
+        expect(Facter::Core::Execution).to receive(:execute).with('/usr/libexec/java_home --failfast', { on_fail: false }).at_least(1).and_return(false)
         expect(Facter.value(:java_version)).to be_nil
       end
     end
     context 'when on other systems' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('MyOS')
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
       end
       let(:facts) { { operatingsystem: 'MyOS' } }
 
       it do
-        expect(Facter::Util::Resolution).to receive(:which).at_least(1).with('java').and_return(false)
+        expect(Facter::Core::Execution).to receive(:which).at_least(1).with('java').and_return(false)
         expect(Facter.value(:java_version)).to be_nil
       end
     end


### PR DESCRIPTION
Prior to this PR, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. This PR aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This PR:

- Replaces all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers