### PR TITLE
(CONT-263) Update minimum required puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -77,7 +77,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
Prior to this commit, and after the work performed in [Hardening manifests](https://github.com/puppetlabs/puppetlabs-java/pull/525), the minimum puppet version requirement was expected to be raised up to 6.24.0 to meet logic requirements.

This commits aims to fix the missing bump.