### PR TITLE
(538) - Unresolved fact fix

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -16,9 +16,9 @@
 Facter.add(:java_version) do
   setcode do
     if ['darwin'].include? Facter.value(:kernel).downcase
-      return unless Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
+      return nil unless Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
     else
-      return unless Facter::Core::Execution.which('java')
+      return nil unless Facter::Core::Execution.which('java')
     end
     version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
     version[%r{\"(.*?)\"}, 1] if version


### PR DESCRIPTION
Fix for issue https://github.com/puppetlabs/puppetlabs-java/issues/538
Prior to this PR, when run on non-darwin systems with no java installed, the custom fact java_version was unresolved.

This was due to an incorrect return type set in
lib/facter/java_version.rb (returned a boolean) as oppose to a string/nil.

This PR hopes to rectify this issue, by ensuring that the returned value for java_version is in the correct format.