### PR TITLE
(WIP) 538-unresolved-fact-fix

### DIFF
--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -19,10 +19,8 @@ Facter.add(:java_version) do
       if Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
         version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
       end
-    else
-      unless Facter::Core::Execution.which('java').nil?
-        version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
-      end
+    elsif Facter::Core::Execution.which('java')
+      version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
     end
     version[%r{\"(.*?)\"}, 1] if version
   end

--- a/lib/facter/java_version.rb
+++ b/lib/facter/java_version.rb
@@ -16,11 +16,14 @@
 Facter.add(:java_version) do
   setcode do
     if ['darwin'].include? Facter.value(:kernel).downcase
-      return nil unless Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
+      if Facter::Core::Execution.execute('/usr/libexec/java_home --failfast', { on_fail: false })
+        version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
+      end
     else
-      return nil unless Facter::Core::Execution.which('java')
+      unless Facter::Core::Execution.which('java').nil?
+        version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
+      end
     end
-    version = Facter::Core::Execution.execute('java -Xmx12m -version 2>&1').lines.find { |line| line.include?('version') }
     version[%r{\"(.*?)\"}, 1] if version
   end
 end


### PR DESCRIPTION
Fix for issue #538

Prior to this PR, work was carried out to update the use of Facter in this module, as the methods present had been deprecated.
This change a bug, as the Facter::Util::Resolution (deprecated) and Facter::Core::Execution (supported) do not behave the same. 

Previously, the deprecated Facter::Util::Resolution.exec statements initially ran a which, that checked that the binary was present before running an exec statement on that binary. The newer instances of Facter's execute statements, attempted to execute even when the binary is not present, which causes an error.

This PR hopes to rectify this issue, by first running a command which checks if the binary is present before executing.