### PR TITLE
Fix shell_escape of unless command

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,12 +26,12 @@ class java::config ( ) {
         # For the stanard packages java::params needs these added.
         if $java::use_java_package_name != $java::default_package_name {
           $command_redhat = ['alternatives', '--install', '/usr/bin/java', 'java', $java::use_java_alternative_path, '20000']
-          $unless_redhat = "alternatives --display java | grep -q ${java::use_java_alternative_path}"
+          $unless_redhat = "alternatives --display java | grep -q ${shell_escape($java::use_java_alternative_path)}"
 
           exec { 'create-java-alternatives':
             path    => '/usr/bin:/usr/sbin:/bin:/sbin',
             command => $command_redhat,
-            unless  => shell_escape($unless_redhat),
+            unless  => $unless_redhat,
             before  => Exec['update-java-alternatives'],
           }
         }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -36,8 +36,22 @@ describe 'java', type: :class do
     let(:params) { { 'package' => 'jre', 'java_alternative' => '/usr/bin/java', 'java_alternative_path' => '/usr/java/jre1.7.0_67/bin/java' } }
 
     it { is_expected.to contain_package('java').with_name('jre') }
-    it { is_expected.to contain_exec('create-java-alternatives').with_command(['alternatives', '--install', '/usr/bin/java', 'java', '/usr/java/jre1.7.0_67/bin/java', '20000']) }
+    it {
+      is_expected.to contain_exec('create-java-alternatives').with(
+      {
+        command: ['alternatives', '--install', '/usr/bin/java', 'java', '/usr/java/jre1.7.0_67/bin/java', '20000'],
+        unless: 'alternatives --display java | grep -q /usr/java/jre1.7.0_67/bin/java',
+      },
+    )
+    }
     it { is_expected.to contain_exec('update-java-alternatives').with_command(['alternatives', '--set', 'java', '/usr/java/jre1.7.0_67/bin/java']) }
+  end
+
+  context 'when select Malicious JRE with alternatives for CentOS 6.3' do
+    let(:facts) { { os: { family: 'RedHat', name: 'CentOS', release: { full: '6.3' }, architecture: 'x86_64' } } }
+    let(:params) { { 'package' => 'jre', 'java_alternative' => '/usr/bin/java', 'java_alternative_path' => '/usr/java ; rm -rf /etc' } }
+
+    it { is_expected.to contain_exec('create-java-alternatives').with_unless('alternatives --display java | grep -q /usr/java\\ \\;\\ rm\\ -rf\\ /etc') }
   end
 
   context 'when select passed value for CentOS 5.3' do


### PR DESCRIPTION
A bug was introduced in 74ea1de22955349598ab01bc530e87d7c754506f .

It resulted in an error:

```
Error: /Stage[main]/Java::Config/Exec[create-java-alternatives]: Could not evaluate:
   Could not find command 'alternatives\'
```

The effective exec was:

```puppet
exec{'create-java-alternatives':
  path    => '/usr/bin:/usr/sbin:/bin:/sbi
  command => ['alternatives', '--install', '/usr/bin/java', 'java', $java::use_java_alternative_path, '20000'],
  unless  => shell_escape("alternatives --display java | grep -q $java::use_java_alternative_path}"),
}
```

This errors since the spaces inside the `shell_escape` are also escaped to `\ `.

This patch only shell_escapes the external supplied string `java::java_alternative_path` which was I expect the object the exercise.

Configuration to trigger the bug, but it should not be hard.

```
class{'java':
 distribution          => 'jdk',
 java_alternative      => '/usr/lib/jvm/java-11-openjdk/bin/java',
 java_alternative_path => '/usr/lib/jvm/java-11-openjdk/bin/java',
 java_home             => '/usr/lib/jvm/java-11-openjdk/',
 package               => 'java-11-openjdk-devel',
 version               => 'present',
}
```