### PR TITLE
Revert "(CONT-784) Rubocop Manual Fixes 5 - RSpec/NoExpectationExample"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,6 +35,14 @@ RSpec/NamedSubject:
     - 'spec/classes/java_spec.rb'
     - 'spec/defines/download_spec.rb'
 
+# Offense count: 12
+# Configuration parameters: AllowedPatterns.
+# AllowedPatterns: ^expect_, ^assert_
+RSpec/NoExpectationExample:
+  Exclude:
+    - 'spec/acceptance/install_spec.rb'
+    - 'spec/unit/facter/java_default_home_spec.rb'
+
 # Offense count: 1
 Style/MixinUsage:
   Exclude:

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -213,38 +213,38 @@ MANIFEST
 describe 'installing' do
   context 'when installing java jre' do
     it 'installs jre' do
-      expect { idempotent_apply(java_class_jre) }.not_to raise_error
+      idempotent_apply(java_class_jre)
     end
   end
 
   context 'when installing java jdk' do
     it 'installs jdk' do
-      expect { idempotent_apply(java_class) }.not_to raise_error
+      idempotent_apply(java_class)
     end
   end
 
   context 'when with failure cases' do
     it 'fails to install java with a blank version' do
-      expect { apply_manifest(blank_version, expect_failures: true) }.not_to raise_error
+      apply_manifest(blank_version, expect_failures: true)
     end
 
     it 'fails to install java with an incorrect distribution' do
-      expect { apply_manifest(incorrect_distro, expect_failures: true) }.not_to raise_error
+      apply_manifest(incorrect_distro, expect_failures: true)
     end
 
     it 'fails to install java with a blank distribution' do
-      expect { apply_manifest(blank_distro, expect_failures: true) }.not_to raise_error
+      apply_manifest(blank_distro, expect_failures: true)
     end
 
     it 'fails to install java with an incorrect package' do
-      expect { apply_manifest(incorrect_package, expect_failures: true) }.not_to raise_error
+      apply_manifest(incorrect_package, expect_failures: true)
     end
 
     it 'fails on debian or RHEL when passed fake java_alternative and path' do
       if os[:family] == 'sles'
-        expect { apply_manifest(bogus_alternative, catch_failures: true) }.not_to raise_error
+        apply_manifest(bogus_alternative, catch_failures: true)
       else
-        expect { apply_manifest(bogus_alternative, expect_failures: true) }.not_to raise_error
+        apply_manifest(bogus_alternative, expect_failures: true)
       end
     end
   end
@@ -259,7 +259,7 @@ describe 'installing' do
     end
 
     it 'installs oracle jdk and jre' do
-      expect { idempotent_apply(install_oracle_jdk_jre) }.not_to raise_error
+      idempotent_apply(install_oracle_jdk_jre)
       jdk_result = shell("test ! -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
       jre_result = shell("test ! -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
       expect(jdk_result.exit_code).to eq(0)
@@ -267,13 +267,13 @@ describe 'installing' do
     end
 
     it 'installs oracle jdk with jce' do
-      expect { idempotent_apply(install_oracle_jdk_jce) }.not_to raise_error
+      idempotent_apply(install_oracle_jdk_jce)
       result = shell("test -e #{install_path}/jdk1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/jre/lib/security/local_policy.jar")
       expect(result.exit_code).to eq(0)
     end
 
     it 'installs oracle jre with jce' do
-      expect { idempotent_apply(install_oracle_jre_jce) }.not_to raise_error
+      idempotent_apply(install_oracle_jre_jce)
       result = shell("test -e #{install_path}/jre1.#{oracle_version_major}.0_#{oracle_version_minor}#{version_suffix}/lib/security/local_policy.jar")
       expect(result.exit_code).to eq(0)
     end
@@ -289,7 +289,7 @@ describe 'installing' do
     end
 
     it 'installs adopt jdk and jre' do
-      expect { idempotent_apply(install_adopt_jdk_jre) }.not_to raise_error
+      idempotent_apply(install_adopt_jdk_jre)
     end
   end
 
@@ -303,7 +303,7 @@ describe 'installing' do
     end
 
     it 'installs adopt jdk and jre' do
-      expect { idempotent_apply(install_adoptium_jdk) }.not_to raise_error
+      idempotent_apply(install_adoptium_jdk)
     end
   end
 
@@ -313,7 +313,7 @@ describe 'installing' do
     end
 
     it 'installs adopt jdk and jre' do
-      expect { idempotent_apply(install_sap_jdk_jre) }.not_to raise_error
+      idempotent_apply(install_sap_jdk_jre)
     end
   end
 end

--- a/spec/unit/facter/java_default_home_spec.rb
+++ b/spec/unit/facter/java_default_home_spec.rb
@@ -31,7 +31,7 @@ describe 'java_default_home' do
     context 'when java is in /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java' do
       it do
         unlink_and_delete('./java_test')
-        expect { symlink_and_test(java_7_path, java_7_home) }.not_to raise_error
+        symlink_and_test(java_7_path, java_7_home)
         unlink_and_delete('./java_test')
       end
     end
@@ -39,7 +39,7 @@ describe 'java_default_home' do
     context 'when java is in /usr/lib/jvm/oracle-java8-jre-amd64/bin/java' do
       it do
         unlink_and_delete('./java_test')
-        expect { symlink_and_test(java_8_path, java_8_home) }.not_to raise_error
+        symlink_and_test(java_8_path, java_8_home)
         unlink_and_delete('./java_test')
       end
     end


### PR DESCRIPTION
This reverts commit 572fd1e1d3f290a54200d46bb1a1be221fb5a6f9.

Reason for revert is that this change while conforming with Rubocop rules results in the error messages from failing applies being hidden.