### PR TITLE
(CONT-1179) - Fixing build failures

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,16 @@ class java (
     default    => '--jre'
   }
 
+  # Enable legacy repo to install net-tools-deprecated package
+  # If SUSE OS major version is >= 15 and minor version is > 3
+  if ($facts['os']['family'] in ['SLES', 'SUSE']) and (versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
+    exec { 'Enable legacy repos':
+      path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+      command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+      unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+    }
+  }
+
   if $facts['os']['family'] == 'Debian' {
     # Needed for update-java-alternatives
     package { 'java-common':

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -144,14 +144,14 @@ describe 'java', type: :class do
   end
 
   context 'when selecting default for SLES 11.3' do
-    let(:facts) { { os: { family: 'Suse', name: 'SLES', release: { full: '11.3' }, architecture: 'x86_64' } } }
+    let(:facts) { { os: { family: 'Suse', name: 'SLES', release: { full: '11.3', major: '11', minor: '3' }, architecture: 'x86_64' } } }
 
     it { is_expected.to contain_package('java').with_name('java-1_6_0-ibm-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.6.0-ibm-1.6.0/') }
   end
 
   context 'when selecting default for SLES 11.4' do
-    let(:facts) { { os: { family: 'Suse', name: 'SLES', release: { full: '11.4' }, architecture: 'x86_64' } } }
+    let(:facts) { { os: { family: 'Suse', name: 'SLES', release: { full: '11.4', major: '11', minor: '4' }, architecture: 'x86_64' } } }
 
     it { is_expected.to contain_package('java').with_name('java-1_7_1-ibm-devel') }
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib64/jvm/java-1.7.1-ibm-1.7.1/') }


### PR DESCRIPTION
## Summary

Enable legacy SP3 repo so that we can leverage the old packages without any issues.

## Additional Context

New release of SUSE 15 introduced new version SP4 which deprecated old packages where `jre`, `jdk` & java related package are few of them. As the package is deprecated with SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)