### PR TITLE
(CAT-1250)-updating legacy SUSE repo name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,8 +115,8 @@ class java (
   if ($facts['os']['family'] in ['SLES', 'SUSE']) and (versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
     exec { 'Enable legacy repos':
       path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-      command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
-      unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
+      unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
     }
   }
 


### PR DESCRIPTION
## Summary
Enable legacy SP5 repo so that we can leverage the old packages without any issues.

## Additional Context
Add any additional context about the problem here. 
New release of SUSE  introduced new version SP5 which deprecated old packages where jre, jdk & java related package are few of them. As the package is deprecated with old SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install. This also affects the modules that is using java internally as a dependency or to install packages.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)