### PR TITLE
(CAT-1696) - Skip CI pipeline for ARM OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
     secrets: "inherit"
     with:
       runs_on: "ubuntu-20.04"
+      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\"]'"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,3 +16,4 @@ jobs:
     secrets: "inherit"
     with:
       runs_on: "ubuntu-20.04"
+      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\"]'"


### PR DESCRIPTION
## Summary

Skip CI pipeline for ARM OS due to unsupportability.
```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, unsupported platform aarch64 (file: /etc/puppetlabs/code/environments/production/modules/java/manifests/adopt.pp, line: 200, column: 7) (file: /root/manifest_20240118_2218_yyzt14.pp, line: 1) on node litmus-2dbdc11f3e18cae9.c.ia-content.internal
```

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)