### PR TITLE
fix: remove puppetlabs-puppet_agent pinning

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,9 +3,7 @@ fixtures:
     archive: "https://github.com/voxpupuli/puppet-archive.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    puppet_agent: 
-      repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.13.0
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'
   symlinks:
     java: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,5 +5,3 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'
-  symlinks:
-    java: "#{source_dir}"


### PR DESCRIPTION
## Summary
This pr removes puppetlabs-puppet_agent pinining which has been introduced during Puppet 8 introduction

## Additional Context
With the pinning in place, the acceptance tests for Debian 12 failed as the pinned version did not yet support that release

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)