### PR TITLE
(CAT-2051): Nightly build failure fixes for puppetlab-java module

### DIFF
--- a/manifests/adopt.pp
+++ b/manifests/adopt.pp
@@ -196,6 +196,8 @@ define java::adopt (
     'i386' : { $arch = 'x86-32' }
     'x86_64' : { $arch = 'x64' }
     'amd64' : { $arch = 'x64' }
+    'arm64' : { $arch = 'aarch64' }
+    'aarch64' : { $arch = 'aarch64' }
     default : {
       fail ("unsupported platform ${$os_architecture}")
     }
@@ -216,7 +218,7 @@ define java::adopt (
   if ( $_version_int == 8 ) {
     $_release_minor_package_name = $release_minor
   } else {
-    $_release_minor_package_name = "_${release_minor}"
+    $_release_minor_package_name = "_${release_minor.split(/\./)[0]}"
   }
 
   case $_package_type {

--- a/manifests/adoptium.pp
+++ b/manifests/adoptium.pp
@@ -100,6 +100,8 @@ define java::adoptium (
     'i386' : { $arch = 'x86-32' }
     'x86_64' : { $arch = 'x64' }
     'amd64' : { $arch = 'x64' }
+    'arm64' : { $arch = 'aarch64' }
+    'aarch64' : { $arch = 'aarch64' }
     default : {
       fail ("unsupported platform ${$os_architecture}")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,7 +120,11 @@ class java::params {
     'Suse': {
       case $facts['os']['name'] {
         'SLES': {
-          if (versioncmp($facts['os']['release']['full'], '12.1') >= 0) {
+          if (versioncmp($facts['os']['release']['full'], '15.5') >= 0) {
+            $jdk_package = 'java-11-openjdk-devel'
+            $jre_package = 'java-11-openjdk'
+            $java_home   = '/usr/lib64/jvm/java-11-openjdk-11/'
+          } elsif (versioncmp($facts['os']['release']['full'], '12.1') >= 0) {
             $jdk_package = 'java-1_8_0-openjdk-devel'
             $jre_package = 'java-1_8_0-openjdk'
             $java_home   = '/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/'

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -99,31 +99,24 @@ install_oracle_jdk_jce = <<MANIFEST
 MANIFEST
 
 # AdoptOpenJDK URLs are quite generic, so tests are enabled by default
-# We need to test version 8 and >8 (here we use 9), because namings are different after version 8
+# We need to test version 9 and 10
 
 adopt_enabled = true unless os[:family].casecmp('SLES').zero?
-adopt_version8_major = '8'
-adopt_version8_minor = '202'
-adopt_version8_build = '08'
 adopt_version9_major = '9'
-adopt_version9_full = '9.0.4'
-adopt_version9_build = '11'
+case os[:arch]
+when 'aarch64', 'arm64'
+  adopt_version9_full = '9'
+  adopt_version9_build = '181'
+else
+  adopt_version9_full = '9.0.4'
+  adopt_version9_build = '11'
+end
+
+adopt_version10_major = '10'
+adopt_version10_full = '10.0.2'
+adopt_version10_build = '13.1'
 
 install_adopt_jdk_jre = <<MANIFEST
-  java::adopt {
-    'test_adopt_jre_version8':
-      version       => '#{adopt_version8_major}',
-      version_major => '#{adopt_version8_major}u#{adopt_version8_minor}',
-      version_minor => 'b#{adopt_version8_build}',
-      java          => 'jre',
-  }
-  java::adopt {
-    'test_adopt_jdk_version8':
-      version       => '#{adopt_version8_major}',
-      version_major => '#{adopt_version8_major}u#{adopt_version8_minor}',
-      version_minor => 'b#{adopt_version8_build}',
-      java          => 'jdk',
-  }
   java::adopt {
     'test_adopt_jre_version9':
       version       => '#{adopt_version9_major}',
@@ -136,6 +129,20 @@ install_adopt_jdk_jre = <<MANIFEST
       version       => '#{adopt_version9_major}',
       version_major => '#{adopt_version9_full}',
       version_minor => '#{adopt_version9_build}',
+      java          => 'jdk',
+  }
+  java::adopt {
+    'test_adopt_jre_version10':
+      version       => '#{adopt_version10_major}',
+      version_major => '#{adopt_version10_full}',
+      version_minor => '#{adopt_version10_build}',
+      java          => 'jre',
+  }
+  java::adopt {
+    'test_adopt_jdk_version10':
+      version       => '#{adopt_version10_major}',
+      version_major => '#{adopt_version10_full}',
+      version_minor => '#{adopt_version10_build}',
       java          => 'jdk',
   }
 MANIFEST
@@ -161,7 +168,7 @@ install_adoptium_jdk = <<MANIFEST
   }
 MANIFEST
 
-sap_enabled = true
+sap_enabled = (os[:arch] == 'x86_64' || os[:arch] == 'amd64')
 sap_version7 = '7'
 sap_version7_full = '7.1.072'
 sap_version8 = '8'


### PR DESCRIPTION
The following issues were addressed:

- Java installation was failing on SLES-15. To resolve this, a new condition was added for SLES 15.5 to check for `java-11-openjdk` instead of `java-1_8_0-openjdk`.
- Support for `aarch64` and `arm64` was added for `Adopt` and `Adoptium` Java installations.
- A condition was added for `SAP Java` to run only on `x86_64` and `amd64` architectures.