### PR TITLE
(CAT-2051): Exclude Debian-12-arm64 platform

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,4 +16,4 @@ jobs:
     secrets: "inherit"
     with:
       runs_on: "ubuntu-20.04"
-      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\"]'"
+      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\", \"Debian-12-arm\"]'"


### PR DESCRIPTION
Excluded Debian-12-arm64 from tests platforms.

Currently, we do not have any tests running for ARM platforms, as support for ARM on both Ubuntu and Redhat was previously excluded. Adding ARM support to this module may require significant changes to the pp files within the manifest folder, which could be treated as a separate project.

CAT-2051 pertains to addressing the existing failures in the modules.
