### PR TITLE
Fix containment of `java::config`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -135,6 +135,8 @@ class java (
     ensure          => $version,
     install_options => $package_options,
     name            => $use_java_package_name,
+    before          => Class['java::config'],
   }
-  -> class { 'java::config': }
+
+  contain java::config # NB evalutation order is important here as the config class relies on variables from the base class having been set before it's evaluated.
 }


### PR DESCRIPTION
In 0dcd91b6e8d2b2519228c534fe4976e9d2a3a1d6 the `anchor` pattern was removed, but not replaced with anything and thus broke the containment of `java::config`.  This restores the original behaviour by using `contain`.

As noted in the code comment, the declaration remains in the same place in the code as evaluation order is important.  `java::config` is a private class and relies on variables from the base class's scope having been set before it is evaluated.

Also see https://github.com/puppetlabs/puppetlabs-java/pull/543#discussion_r1532211505