### PR TITLE
Add support for Debian 13 (trixie)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,9 @@ class java::params {
         default   => $facts['os']['architecture']
       }
       case $facts['os']['release']['major'] {
+        '13': {
+          $openjdk = 21
+        }
         '12', '24.04': {
           $openjdk = 17
         }

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,8 @@
       "operatingsystemrelease": [
         "10",
         "11",
-        "12"
+        "12",
+        "13"
       ]
     },
     {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -46,6 +46,24 @@ describe 'java', type: :class do
     end
   end
 
+  context 'on Debian Trixie (13)' do
+    let(:facts) { { os: { family: 'Debian', name: 'Debian', lsb: { distcodename: 'trixie' }, release: { major: '13' }, architecture: 'amd64' } } }
+
+    context 'when selecting jdk' do
+      let(:params) { { 'distribution' => 'jdk' } }
+
+      it { is_expected.to contain_package('java').with_name('openjdk-21-jdk') }
+      it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.21.0-openjdk-amd64/') }
+    end
+
+    context 'when selecting jre' do
+      let(:params) { { 'distribution' => 'jre' } }
+
+      it { is_expected.to contain_package('java').with_name('openjdk-21-jre-headless') }
+      it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.21.0-openjdk-amd64/') }
+    end
+  end
+
   context 'on Ubuntu Bionic (18.04)' do
     let(:facts) { { os: { family: 'Debian', name: 'Ubuntu', lsb: { distcodename: 'bionic' }, release: { major: '18.04' }, architecture: 'amd64' } } }
 


### PR DESCRIPTION
## Summary

Debian v13 AKA trixie was released on 2025-08-09 as Debian's new stable release.

## Additional Context

Based on commit 00c7eb14802f1658a24d842d8f8b9717ca2b7f5b for Debian 12 support

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (we're using this $internally)