### PR TITLE
(MODULES-11917) Default RHEL 10 to OpenJDK 21

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,13 +11,22 @@ class java::params {
         'AlmaLinux', 'Rocky', 'RedHat', 'CentOS', 'OracleLinux', 'Scientific', 'OEL', 'SLC', 'CloudLinux': {
           # See PR#160 / c8e46b5 for why >= 6.3 < 7.1
           if (versioncmp($facts['os']['release']['full'], '7.1') < 0) {
-            $openjdk = '1.7.0'
+            $openjdk     = '1.7.0'
+            $jdk_package = "java-${openjdk}-openjdk-devel"
+            $jre_package = "java-${openjdk}-openjdk"
+            $java_home   = "/usr/lib/jvm/java-${openjdk}/"
+          } elsif (versioncmp($facts['os']['release']['full'], '10') >= 0) {
+            # RHEL 10 dropped java-1.8.0-openjdk; default to the current LTS.
+            $openjdk     = '21'
+            $jdk_package = "java-${openjdk}-openjdk-devel"
+            $jre_package = "java-${openjdk}-openjdk"
+            $java_home   = "/usr/lib/jvm/java-${openjdk}-openjdk/"
           } else {
-            $openjdk = '1.8.0'
+            $openjdk     = '1.8.0'
+            $jdk_package = "java-${openjdk}-openjdk-devel"
+            $jre_package = "java-${openjdk}-openjdk"
+            $java_home   = "/usr/lib/jvm/java-${openjdk}/"
           }
-          $jdk_package = "java-${openjdk}-openjdk-devel"
-          $jre_package = "java-${openjdk}-openjdk"
-          $java_home   = "/usr/lib/jvm/java-${openjdk}/"
         }
         'Fedora': {
           if (versioncmp($facts['os']['release']['full'], '21') < 0) {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -10,6 +10,13 @@ describe 'java', type: :class do
     it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-1.8.0/') }
   end
 
+  context 'when selecting openjdk for RedHat 10' do
+    let(:facts) { { os: { family: 'RedHat', name: 'RedHat', release: { full: '10.0', major: '10' }, architecture: 'x86_64' } } }
+
+    it { is_expected.to contain_package('java').with_name('java-21-openjdk-devel') }
+    it { is_expected.to contain_file_line('java-home-environment').with_line('JAVA_HOME=/usr/lib/jvm/java-21-openjdk/') }
+  end
+
   context 'on Debian Buster (10.0)' do
     let(:facts) { { os: { family: 'Debian', name: 'Debian', lsb: { distcodename: 'buster' }, release: { major: '10' }, architecture: 'amd64' } } }
 


### PR DESCRIPTION
## What

RHEL 10 dropped the `java-1.8.0-openjdk` packages, so the RedHat-family default of Java 8 caused `dnf install java-1.8.0-openjdk-devel` to fail on RHEL 10 (`Unable to find a match`), breaking the install acceptance tests.

This adds a version branch in `manifests/params.pp` so:

- **RHEL ≥ 10** → OpenJDK 21 (`java-21-openjdk{,-devel}`, `java_home = /usr/lib/jvm/java-21-openjdk/`)
- **RHEL 7.1–9** → Java 8 (unchanged)
- **RHEL < 7.1** → 1.7.0 (unchanged)

Adds spec coverage in `spec/classes/java_spec.rb`.

## Why

Split out of #MODULES-11704 (Puppet 9 support) — the RHEL 10 default is independent of Puppet 9, so it targets `main` directly on its own ticket.

Jira: [MODULES-11917](https://perforce.atlassian.net/browse/MODULES-11917)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
